### PR TITLE
misc dockerfile and readme fixes

### DIFF
--- a/Clean_Docker_LANDIS-II_8_AllExtensions/Dockerfile
+++ b/Clean_Docker_LANDIS-II_8_AllExtensions/Dockerfile
@@ -498,7 +498,7 @@ RUN cd $LANDIS_FOLDER/Tool-Console/src && dotnet build -c Release
 ## Testing
 ################################################################
 
-ARG TESTS_DIR="$LANDIS_DIR/tests"
+ARG TESTS_DIR="$LANDIS_FOLDER/tests"
 
 COPY ./tests $TESTS_DIR
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ docker pull ghcr.io/landis-ii-foundation/<imagename>:main
 	> - `<directory>` specifies the Docker 'build context', which determines the set of local files
 	>   the bulid process has access to. If `<directory>` is specified as the root directory of the repository,
 	>   then shared files or directories (e.g., `extension_files/`, `scripts/`, and any `*.yaml` files
-	>   can be passed to the build process. Whereas, if `<directory> is specified as one of the repository
+	>   can be passed to the build process. Whereas, if `<directory>` is specified as one of the repository
 	>   subdirectories (e.g., `Clean_Docker_LANDIS-II_8_AllExtensions`), then the build will only use
 	>   the files contained in that subdirectory.
 	> - `<path/to/Dockerfile>` specifies the *relative* path to the `Dockerfile` used to build the image.


### PR DESCRIPTION
@Klemet this fixes the missing `$LANDIS_DIR` error reported by Shike, and fixes a typo in a README.