### PR TITLE
docs: improve README files for users and developers (closes #20)

### DIFF
--- a/Clean_Docker_LANDIS-II_7_AllExtensions/README.md
+++ b/Clean_Docker_LANDIS-II_7_AllExtensions/README.md
@@ -1,5 +1,9 @@
 # Clean_Docker_LANDIS-II_7_AllExtensions
 
+> [!WARNING]
+> **This image is deprecated.** Use [`landis-ii-v7-release`](../Docker-LANDIS-II-v7-release/) instead.
+> It provides the same extensions with improved build infrastructure and a pre-built image you can pull without building locally.
+
 This folder contains the Dockerfile necessary to create the Docker image that will contain LANDIS-II v7 and all of its available extensions.
 
 All extensions are in their most recent version compatible with v7, before the switch to v8; except for Biomass Harvest, whose latest version before v7 had a compatibility issue (see comments in the Dockerfile).

--- a/Clean_Docker_LANDIS-II_8_AllExtensions/README.md
+++ b/Clean_Docker_LANDIS-II_8_AllExtensions/README.md
@@ -1,5 +1,9 @@
 # Clean_Docker_LANDIS-II_8_AllExtensions
 
+> [!WARNING]
+> **This image is deprecated.** Use [`landis-ii-v8-release`](../Docker-LANDIS-II-v8-release/) instead.
+> It provides the same extensions with improved build infrastructure, Ubuntu 24.04, and a pre-built image you can pull without building locally.
+
 This folder contains the Dockerfile necessary to create the Docker image that will contain LANDIS-II v8 and all of its available extensions in their latest versions.
 
 Some extensions are still yet not available for LANDIS-II v8 and will be updated when possible.

--- a/Docker-LANDIS-II-v7-release/README.md
+++ b/Docker-LANDIS-II-v7-release/README.md
@@ -1,94 +1,173 @@
 # Docker-LANDIS-II-v7-release
 
-This image closely follows the original `Clean_Docker_LANDIS-II_7_AllExtensions` image with the following enhancements:
+LANDIS-II v7 (Ubuntu 22.04) with a fixed, tested set of extensions defined in [`extensions-v7-release.yaml`](../extensions-v7-release.yaml).
 
-- places the LANDIS-II code at `/opt/landis-ii` instead of `/bin/LANDIS_Linux`,
-  because `/opt` is the standard location for software not provided via the OS package manager;
-- extension repos and commit SHAs are recorded in a shared `extensions-v7-release.yaml` file,
-  rather than in the Dockerfile, which should be easier to update and maintain going forward;
-- likewise, library repos and commit SHAs are recorded in a shared `libraries-v7-release.yaml` file,
-  rather than in the Dockerfile, which should be easier to update and maintain going forward;
-- install additional libraries before installing extensions;
-- use single commit for ForCS 3.1;
-- uses shared versions of the Forest Roads and Magic Harvest extensions' `.csproj` files,
-  located in the `extension_files_v7/` directory;
-- rewrote and simplified various installation scripts to use `bash`;
-  these are shared in the `scripts/` directory and can be used directly with other image 'flavours';
-  - uses `yq` to parse yaml files in bash;
-  - uses `xmlstarlet` to parse and edit XML in the `.csproj` files;
-- shared tests are copied from the `tests/` directory and run as part of the build process;
+**For users:** pull the pre-built image (no build step required).
+**For developers:** build the image locally using the instructions below.
+
+## Quick start: use the pre-built image
+
+```shell
+docker pull ghcr.io/landis-ii-foundation/landis-ii-v7-release:main
+```
+
+Then run a simulation (replace the path with your scenario folder):
+
+```shell
+## Linux / macOS
+docker run --rm \
+  --cpus=4 \
+  --memory=64g \
+  --mount type=bind,src="/path/to/your/scenario",dst=/scenarioFolder \
+  ghcr.io/landis-ii-foundation/landis-ii-v7-release:main \
+  /bin/sh -c "cd /scenarioFolder && dotnet \$LANDIS_CONSOLE scenario.txt"
+
+## Windows (PowerShell)
+docker run --rm `
+  --cpus=4 `
+  --memory=64g `
+  --mount type=bind,src="C:\path\to\your\scenario",dst=/scenarioFolder `
+  ghcr.io/landis-ii-foundation/landis-ii-v7-release:main `
+  /bin/sh -c "cd /scenarioFolder && dotnet `$LANDIS_CONSOLE scenario.txt"
+```
+
+## Included extensions
+
+See [`extensions-v7-release.yaml`](../extensions-v7-release.yaml) and [`libraries-v7-release.yaml`](../libraries-v7-release.yaml) for the exact commit SHAs used.
+
+**Succession**
+
+| Extension |
+| --------- |
+| Age-Only Succession |
+| Biomass Succession |
+| ForCS Succession |
+| NECN Succession |
+| PnET Succession |
+
+**Disturbance and other**
+
+| Extension |
+| --------- |
+| Base BDA |
+| Base Fire |
+| Base Harvest |
+| Base Wind |
+| BFOLDS Fire (precompiled DLL — source not yet open) |
+| Biomass Browse |
+| Biomass Harvest |
+| Biomass Hurricane |
+| Dynamic Biomass Fuels |
+| Dynamic Fire System |
+| Dynamic Fuel System |
+| Land Use Plus |
+| LinearWind |
+| Root Rot |
+| Social Climate Fire |
+| SOSIEL Harvest |
+| Forest Roads Simulation |
+| Magic Harvest |
+
+**Output**
+
+| Extension |
+| --------- |
+| Output Biomass |
+| Output Biomass By Age |
+| Output Biomass Community |
+| Output Biomass (PnET) |
+| Output Biomass Reclass |
+| Output Cohort Statistics |
+| Output Landscape Habitat |
+| Output Max Species Age |
+| Output Wildlife Habitat |
+| Local Habitat Suitability Output |
+
+## Enhancements over `landis-ii-v7-linux`
+
+This image supersedes `Clean_Docker_LANDIS-II_7_AllExtensions` with the following improvements:
+
+- LANDIS-II placed at `/opt/landis-ii` (standard location for third-party software);
+- extension and library versions defined in shared `*.yaml` files, not hardcoded in the Dockerfile;
+- shared `.csproj` files for Forest Roads and Magic Harvest extensions (`extension_files_v7/`);
+- build scripts rewritten in `bash`, shared in `scripts/`, reusable across image flavours;
+- `yq` used to parse yaml; `xmlstarlet` used to edit `.csproj` XML;
+- shared tests (`tests/`) run as part of the build;
 
 ## Build the image
 
-### Linux (bash)
+Build from the repository root so that shared files (`extension_files_v7/`, `scripts/`, `*.yaml`) are available.
+
+### Linux / macOS (bash)
 
 ```shell
 cd ~/Tool-Docker-Apptainer
 
 docker build . \
   -f Docker-LANDIS-II-v7-release/Dockerfile \
-  -t landis-ii-7-release:release
+  -t landis-ii-v7-release:release
 ```
 
-### Windows (Powershell)
+### Windows (PowerShell)
 
 ```shell
 cd ~/Tool-Docker-Apptainer
 
 docker build . `
   -f Docker-LANDIS-II-v7-release/Dockerfile `
-  -t landis-ii-7-release:release
+  -t landis-ii-v7-release:release
 ```
 
-## Run a container
+## Run a locally built container
+
+Replace `landis-ii-v7-release:release` with `ghcr.io/landis-ii-foundation/landis-ii-v7-release:main` if you pulled the pre-built image instead.
 
 ### Interactive container
 
-#### Linux (bash)
+#### Linux / macOS (bash)
 
 ```shell
 docker run -it \
   --cpus=4 \
   --memory=64g \
-  --mount type=bind,src="<SCENARIO_FOLDER_FULL_PATH_ON_COMPUTER>",dst=/scenarioFolder \
+  --mount type=bind,src="/path/to/your/scenario",dst=/scenarioFolder \
   --name landis01 \
-  landis-ii-7-release:release
+  landis-ii-v7-release:release
 ```
 
-#### Windows (Powershell)
+#### Windows (PowerShell)
 
 ```shell
 docker run -it `
   --cpus=4 `
   --memory=64g `
-  --mount type=bind,src="<SCENARIO_FOLDER_FULL_PATH_ON_COMPUTER>",dst=/scenarioFolder `
+  --mount type=bind,src="C:\path\to\your\scenario",dst=/scenarioFolder `
   --name landis01 `
-  landis-ii-7-release:release
+  landis-ii-v7-release:release
 ```
 
-### Non-interactive container
+### Non-interactive container (run a single simulation)
 
-E.g., run a single LANDIS-II simulation
-
-#### Linux (bash)
+#### Linux / macOS (bash)
 
 ```shell
-docker run \
+docker run --rm \
   --cpus=4 \
   --memory=64g \
-  --mount type=bind,src="<SCENARIO_FOLDER_FULL_PATH_ON_COMPUTER>",dst=/scenarioFolder \
+  --mount type=bind,src="/path/to/your/scenario",dst=/scenarioFolder \
   --name landis01 \
-  landis-ii-7-release:release /bin/sh -c "cd /scenarioFolder && dotnet \$LANDIS_CONSOLE scenario.txt"
+  landis-ii-v7-release:release \
+  /bin/sh -c "cd /scenarioFolder && dotnet \$LANDIS_CONSOLE scenario.txt"
 ```
 
-#### Windows (Powershell)
+#### Windows (PowerShell)
 
 ```shell
-docker run `
+docker run --rm `
   --cpus=4 `
   --memory=64g `
-  --mount type=bind,src="<SCENARIO_FOLDER_FULL_PATH_ON_COMPUTER>",dst=/scenarioFolder \
+  --mount type=bind,src="C:\path\to\your\scenario",dst=/scenarioFolder `
   --name landis01 `
-  landis-ii-7-release:release /bin/sh -c "cd /scenarioFolder && dotnet `$LANDIS_CONSOLE scenario.txt"
+  landis-ii-v7-release:release `
+  /bin/sh -c "cd /scenarioFolder && dotnet `$LANDIS_CONSOLE scenario.txt"
 ```
-

--- a/Docker-LANDIS-II-v8-R/README.md
+++ b/Docker-LANDIS-II-v8-R/README.md
@@ -1,27 +1,58 @@
 # LANDIS-II-v8-R
 
-This image closely follows the `Docker-LANDIS-II-release` image but uses `rocker/r-ver:4.5.1` as the base image,
-and adds geospatial libraries.
+LANDIS-II v8 with R 4.6.0, built on [`rocker/r-ver:4.6.0`](https://rocker-project.org/images/versioned/r-ver.html). Includes LANDIS-II, geospatial libraries, and a full R environment — but no RStudio Server. For an interactive RStudio workflow, use [`landis-ii-v8-rstudio`](../Docker-LANDIS-II-v8-Rstudio/) instead.
+
+**For users:** pull the pre-built image (no build step required).
+**For developers:** build the image locally using the instructions below.
+
+## Quick start: use the pre-built image
+
+```shell
+docker pull ghcr.io/landis-ii-foundation/landis-ii-v8-r:main
+```
+
+Run an interactive R session with your project files available inside the container:
+
+```shell
+## Linux / macOS
+docker run -it --rm \
+  --cpus=4 \
+  --memory=64g \
+  --mount type=bind,src="/path/to/your/project",dst=/home/project \
+  ghcr.io/landis-ii-foundation/landis-ii-v8-r:main \
+  R
+
+## Windows (PowerShell)
+docker run -it --rm `
+  --cpus=4 `
+  --memory=64g `
+  --mount type=bind,src="C:\path\to\your\project",dst=/home/project `
+  ghcr.io/landis-ii-foundation/landis-ii-v8-r:main `
+  R
+```
+
+**See also:** <https://rocker-project.org/images/versioned/r-ver.html#how-to-use>
 
 ## Build the image
 
-### Linux (bash)
+Build from the repository root so that shared files are available.
+
+### Linux / macOS (bash)
 
 ```shell
 cd ~/Tool-Docker-Apptainer
 
 docker build . \
   -f Docker-LANDIS-II-v8-R/Dockerfile \
-  -t landis-ii-8-r:release
+  -t landis-ii-v8-r:release
 ```
 
-## Run a container
-
-### Linux (bash)
+### Windows (PowerShell)
 
 ```shell
-## example
-docker run -d -it landis-ii-8-r:release
-```
+cd ~/Tool-Docker-Apptainer
 
-**See also:** <https://rocker-project.org/images/versioned/r-ver.html#how-to-use>
+docker build . `
+  -f Docker-LANDIS-II-v8-R/Dockerfile `
+  -t landis-ii-v8-r:release
+```

--- a/Docker-LANDIS-II-v8-Rstudio/README.md
+++ b/Docker-LANDIS-II-v8-Rstudio/README.md
@@ -1,35 +1,29 @@
 # LANDIS-II-v8-Rstudio
 
-This image closely follows the `Docker-LANDIS-II-release` image but uses `rocker/geospatial:4.5.1` as the base image,
-so it provides an Rstudio Server instance for interactive workflows.
+LANDIS-II v8 with R 4.6.0 and RStudio Server, built on [`rocker/geospatial:4.6.0`](https://rocker-project.org/images/versioned/rstudio.html). Intended for interactive workflows: connect to the running container from your browser to use RStudio alongside LANDIS-II.
 
-## Build the image
+**For users:** pull the pre-built image (no build step required).
+**For developers:** build the image locally using the instructions below.
 
-### Linux (bash)
+## Quick start: use the pre-built image
 
 ```shell
-cd ~/Tool-Docker-Apptainer
-
-docker build . \
-  -f Docker-LANDIS-II-v8-Rstudio/Dockerfile \
-  -t landis-ii-8-rstudio:release
+docker pull ghcr.io/landis-ii-foundation/landis-ii-v8-rstudio:main
 ```
 
 ## Run a container
 
-- specify the local port to use to connect to the container by passing `-p` with appropriate arguments
-  (e.g., `-p 127.0.0.1:8080:8787` allows connections on local port 8080; 8787 is the port used by Rstudio on the container);
-- a custom `PASSWORD` can be specified (if not specified, a random one will be used and displayed *once* at container launch);
-- local directories can be mounted as above;
-- `USERID` and `GROUPID` specify the user and group ids, respectively, and can be specified
-  to ensure user file permissions of the container match those of the mounted volume (defaults: `1000`)
-  (see <https://rocker-project.org/images/versioned/rstudio.html#userid-and-groupid>);
-- limit system resources available to the container by passing e.g., `--memory=64g` and `--cpus=8`;
+When launching an instance of the container:
 
-### Linux (bash)
+- specify the local port with `-p` (e.g., `-p 127.0.0.1:8080:8787` maps local port 8080 to RStudio's port 8787 inside the container);
+- set a `PASSWORD` for the `rstudio` user (if omitted, a random one is printed once at launch);
+- mount local directories with `--mount` to make your project files accessible;
+- set `USERID` and `GROUPID` to match your host user/group IDs so that file permissions on mounted volumes work correctly (defaults: `1000`);
+- limit resources with `--memory` and `--cpus`;
+
+### Linux / macOS (bash)
 
 ```shell
-## example
 docker run -d -it \
   -e USERID=$(id -u) \
   -e GROUPID=$(id -g) \
@@ -37,14 +31,53 @@ docker run -d -it \
   --cpus=4 \
   --memory=64g \
   -p 127.0.0.1:8080:8787 \
-  --mount type=bind,source=/home/$(id -un)/projects/LANDIS-II,target=/home/rstudio/LANDIS-II \
+  --mount type=bind,source="/path/to/your/project",target=/home/rstudio/project \
   --name landis01 \
-  landis-ii-8-rstudio:release
+  ghcr.io/landis-ii-foundation/landis-ii-v8-rstudio:main
 ```
 
-### Access the Rstudio instance
+### Windows (PowerShell)
 
-Open your web browser and connect to `localhost:8080`.
-Log in using username `rstudio` and the password set above.
+```shell
+docker run -d -it `
+  -e PASSWORD='<MySecretPassword>' `
+  --cpus=4 `
+  --memory=64g `
+  -p 127.0.0.1:8080:8787 `
+  --mount type=bind,source="C:\path\to\your\project",target=/home/rstudio/project `
+  --name landis01 `
+  ghcr.io/landis-ii-foundation/landis-ii-v8-rstudio:main
+```
+
+> **Note for Windows users:** `$(id -u)` and `$(id -g)` are Linux/macOS shell substitutions and are not available in PowerShell. Omitting `USERID`/`GROUPID` uses the defaults (1000); if you encounter permission issues on mounted files, set them explicitly (e.g., `-e USERID=1000`).
+
+### Access the RStudio instance
+
+Open your browser and navigate to `http://localhost:8080`.
+Log in with username `rstudio` and the password you set above.
 
 **See also:** <https://rocker-project.org/images/versioned/rstudio.html#how-to-use>
+
+## Build the image
+
+Build from the repository root so that shared files are available.
+
+### Linux / macOS (bash)
+
+```shell
+cd ~/Tool-Docker-Apptainer
+
+docker build . \
+  -f Docker-LANDIS-II-v8-Rstudio/Dockerfile \
+  -t landis-ii-v8-rstudio:release
+```
+
+### Windows (PowerShell)
+
+```shell
+cd ~/Tool-Docker-Apptainer
+
+docker build . `
+  -f Docker-LANDIS-II-v8-Rstudio/Dockerfile `
+  -t landis-ii-v8-rstudio:release
+```

--- a/Docker-LANDIS-II-v8-UCL2-release/README.md
+++ b/Docker-LANDIS-II-v8-UCL2-release/README.md
@@ -1,95 +1,164 @@
 # Docker-LANDIS-II-v8-UCLv2-release
 
-This image closely follows the original `Clean_Docker_LANDIS-II_8_AllExtensions` image with the following enhancements:
+LANDIS-II v8 (Ubuntu 24.04) with extensions updated for **Universal Cohort Library (UCL) v2**, defined in [`extensions-v8-UCL2-release.yaml`](../extensions-v8-UCL2-release.yaml). UCL v2 fixes a significant biomass-removal bug present in earlier extensions — see the [warning in the main README](../README.md) for details.
 
-- uses Ubuntu 24.04 (noble) as the base image instead of 22.04 (jammy);
-- install `dotnet` from the `apt` repositories rather than installing and configuring manually;
-- uses more recent extension commits for several other extensions;
-- places the LANDIS-II code at `/opt/landis-ii` instead of `/bin/LANDIS_Linux`,
-  because `/opt` is the standard location for software not provided via the OS package manager;
-- extension repos and commit SHAs are recorded in a shared `extensions-v8-release.yaml` file,
-  rather than in the Dockerfile, which should be easier to update and maintain going forward;
-- likewise, library repos and commit SHAs are recorded in a shared `libraries-v8-release.yaml` file,
-  rather than in the Dockerfile, which should be easier to update and maintain going forward;
-- uses shared versions of the Forest Roads and Magic Harvest extensions' `.csproj` files,
-  located in the `extension_files/` directory;
-- rewrote and simplified various installation scripts to use `bash`;
-  these are shared in the `scripts/` directory and can be used directly with other image 'flavours';
-  - uses `yq` to parse yaml files in bash;
-  - uses `xmlstarlet` to parse and edit XML in the `.csproj` files;
-- shared tests are copied from the `tests/` directory and run as part of the build process;
-- updates for Universal Cohort Library (UCL) v2;
+> **Note:** Some extensions are still pending UCL v2 updates and are therefore not included. Extensions not yet updated include: PnET Succession, Base BDA, Dynamic Biomass Fuels, Dynamic Fire System, LinearWind, Forest Roads Simulation, Magic Harvest, Output Biomass (PnET), Output Wildlife Habitat, and Local Habitat Suitability Output. Use [`landis-ii-v8-release`](../Docker-LANDIS-II-v8-release/) if you need those extensions.
+
+**For users:** pull the pre-built image (no build step required).
+**For developers:** build the image locally using the instructions below.
+
+## Quick start: use the pre-built image
+
+```shell
+docker pull ghcr.io/landis-ii-foundation/landis-ii-v8-uclv2-release:main
+```
+
+Then run a simulation (replace the path with your scenario folder):
+
+```shell
+## Linux / macOS
+docker run --rm \
+  --cpus=4 \
+  --memory=64g \
+  --mount type=bind,src="/path/to/your/scenario",dst=/scenarioFolder \
+  ghcr.io/landis-ii-foundation/landis-ii-v8-uclv2-release:main \
+  /bin/sh -c "cd /scenarioFolder && dotnet \$LANDIS_CONSOLE scenario.txt"
+
+## Windows (PowerShell)
+docker run --rm `
+  --cpus=4 `
+  --memory=64g `
+  --mount type=bind,src="C:\path\to\your\scenario",dst=/scenarioFolder `
+  ghcr.io/landis-ii-foundation/landis-ii-v8-uclv2-release:main `
+  /bin/sh -c "cd /scenarioFolder && dotnet `$LANDIS_CONSOLE scenario.txt"
+```
+
+## Included extensions
+
+See [`extensions-v8-UCL2-release.yaml`](../extensions-v8-UCL2-release.yaml) and [`libraries-v8-release.yaml`](../libraries-v8-release.yaml) for the exact commit SHAs used.
+
+**Succession**
+
+| Extension |
+| --------- |
+| Biomass Succession |
+| ForCS Succession |
+| NECN Succession |
+
+**Disturbance and other**
+
+| Extension |
+| --------- |
+| Base Fire |
+| Base Wind |
+| Biomass Harvest |
+| Biomass Hurricane |
+| Land Use Plus |
+| Social Climate Fire |
+| Forest Roads Simulation |
+| Magic Harvest |
+
+**Output**
+
+| Extension |
+| --------- |
+| Output Biomass |
+| Output Biomass By Age |
+| Output Biomass Community |
+| Output Biomass Reclass |
+| Output Cohort Statistics |
+| Output Max Species Age |
+
+## Enhancements over `landis-ii-v8-release`
+
+This image builds on `Docker-LANDIS-II-v8-release` with the following addition:
+
+- extensions updated for Universal Cohort Library (UCL) v2, fixing a biomass-removal bug;
+
+All other enhancements from `Docker-LANDIS-II-v8-release` also apply:
+
+- Ubuntu 24.04 (noble) base image;
+- `dotnet` installed from the `apt` repositories;
+- LANDIS-II placed at `/opt/landis-ii`;
+- extension and library versions defined in shared `*.yaml` files;
+- shared `.csproj` files for Forest Roads and Magic Harvest extensions (`extension_files/`);
+- build scripts in `bash`, shared in `scripts/`;
+- shared tests (`tests/`) run as part of the build;
 
 ## Build the image
 
-### Linux (bash)
+Build from the repository root so that shared files (`extension_files/`, `scripts/`, `*.yaml`) are available.
+
+### Linux / macOS (bash)
 
 ```shell
 cd ~/Tool-Docker-Apptainer
 
 docker build . \
   -f Docker-LANDIS-II-v8-UCL2-release/Dockerfile \
-  -t landis-ii-8-uclv2-release:release
+  -t landis-ii-v8-uclv2-release:release
 ```
 
-### Windows (Powershell)
+### Windows (PowerShell)
 
 ```shell
 cd ~/Tool-Docker-Apptainer
 
 docker build . `
   -f Docker-LANDIS-II-v8-UCL2-release/Dockerfile `
-  -t landis-ii-8-uclv2-release:release
+  -t landis-ii-v8-uclv2-release:release
 ```
 
-## Run a container
+## Run a locally built container
+
+Replace `landis-ii-v8-uclv2-release:release` with `ghcr.io/landis-ii-foundation/landis-ii-v8-uclv2-release:main` if you pulled the pre-built image instead.
 
 ### Interactive container
 
-#### Linux (bash)
+#### Linux / macOS (bash)
 
 ```shell
 docker run -it \
   --cpus=4 \
   --memory=64g \
-  --mount type=bind,src="<SCENARIO_FOLDER_FULL_PATH_ON_COMPUTER>",dst=/scenarioFolder \
+  --mount type=bind,src="/path/to/your/scenario",dst=/scenarioFolder \
   --name landis01 \
-  landis-ii-8-UCLv2-release:release
+  landis-ii-v8-uclv2-release:release
 ```
 
-#### Windows (Powershell)
+#### Windows (PowerShell)
 
 ```shell
 docker run -it `
   --cpus=4 `
   --memory=64g `
-  --mount type=bind,src="<SCENARIO_FOLDER_FULL_PATH_ON_COMPUTER>",dst=/scenarioFolder `
+  --mount type=bind,src="C:\path\to\your\scenario",dst=/scenarioFolder `
   --name landis01 `
-  landis-ii-8-UCLv2-release:release
+  landis-ii-v8-uclv2-release:release
 ```
 
-### Non-interactive container
+### Non-interactive container (run a single simulation)
 
-E.g., run a single LANDIS-II simulation
-
-#### Linux (bash)
+#### Linux / macOS (bash)
 
 ```shell
-docker run \
+docker run --rm \
   --cpus=4 \
   --memory=64g \
-  --mount type=bind,src="<SCENARIO_FOLDER_FULL_PATH_ON_COMPUTER>",dst=/scenarioFolder \
+  --mount type=bind,src="/path/to/your/scenario",dst=/scenarioFolder \
   --name landis01 \
-  landis-ii-8:release /bin/sh -c "cd /scenarioFolder && dotnet \$LANDIS_CONSOLE scenario.txt"
+  landis-ii-v8-uclv2-release:release \
+  /bin/sh -c "cd /scenarioFolder && dotnet \$LANDIS_CONSOLE scenario.txt"
 ```
 
-#### Windows (Powershell)
+#### Windows (PowerShell)
 
 ```shell
-docker run `
+docker run --rm `
   --cpus=4 `
   --memory=64g `
-  --mount type=bind,src="<SCENARIO_FOLDER_FULL_PATH_ON_COMPUTER>",dst=/scenarioFolder `
+  --mount type=bind,src="C:\path\to\your\scenario",dst=/scenarioFolder `
   --name landis01 `
-  landis-ii-8:release /bin/sh -c "cd /scenarioFolder && dotnet `$LANDIS_CONSOLE scenario.txt"
+  landis-ii-v8-uclv2-release:release `
+  /bin/sh -c "cd /scenarioFolder && dotnet `$LANDIS_CONSOLE scenario.txt"
 ```

--- a/Docker-LANDIS-II-v8-release/README.md
+++ b/Docker-LANDIS-II-v8-release/README.md
@@ -1,95 +1,167 @@
 # Docker-LANDIS-II-v8-release
 
-This image closely follows the original `Clean_Docker_LANDIS-II_8_AllExtensions` image with the following enhancements:
+LANDIS-II v8 (Ubuntu 24.04) with a fixed, tested set of extensions defined in [`extensions-v8-release.yaml`](../extensions-v8-release.yaml).
 
-- uses Ubuntu 24.04 (noble) as the base image instead of 22.04 (jammy);
-- install `dotnet` from the `apt` repositories rather than installing and configuring manually;
-- uses more recent extension commits for several other extensions;
-- places the LANDIS-II code at `/opt/landis-ii` instead of `/bin/LANDIS_Linux`,
-  because `/opt` is the standard location for software not provided via the OS package manager;
-- extension repos and commit SHAs are recorded in a shared `extensions-v8-release.yaml` file,
-  rather than in the Dockerfile, which should be easier to update and maintain going forward;
-- likewise, library repos and commit SHAs are recorded in a shared `libraries-v8-release.yaml` file,
-  rather than in the Dockerfile, which should be easier to update and maintain going forward;
-- uses shared versions of the Forest Roads and Magic Harvest extensions' `.csproj` files,
-  located in the `extension_files/` directory;
-- rewrote and simplified various installation scripts to use `bash`;
-  these are shared in the `scripts/` directory and can be used directly with other image 'flavours';
-  - uses `yq` to parse yaml files in bash;
-  - uses `xmlstarlet` to parse and edit XML in the `.csproj` files;
-- shared tests are copied from the `tests/` directory and run as part of the build process;
+**For users:** pull the pre-built image (no build step required).
+**For developers:** build the image locally using the instructions below.
+
+## Quick start: use the pre-built image
+
+```shell
+docker pull ghcr.io/landis-ii-foundation/landis-ii-v8-release:main
+```
+
+Then run a simulation (replace the path with your scenario folder):
+
+```shell
+## Linux / macOS
+docker run --rm \
+  --cpus=4 \
+  --memory=64g \
+  --mount type=bind,src="/path/to/your/scenario",dst=/scenarioFolder \
+  ghcr.io/landis-ii-foundation/landis-ii-v8-release:main \
+  /bin/sh -c "cd /scenarioFolder && dotnet \$LANDIS_CONSOLE scenario.txt"
+
+## Windows (PowerShell)
+docker run --rm `
+  --cpus=4 `
+  --memory=64g `
+  --mount type=bind,src="C:\path\to\your\scenario",dst=/scenarioFolder `
+  ghcr.io/landis-ii-foundation/landis-ii-v8-release:main `
+  /bin/sh -c "cd /scenarioFolder && dotnet `$LANDIS_CONSOLE scenario.txt"
+```
+
+## Included extensions
+
+See [`extensions-v8-release.yaml`](../extensions-v8-release.yaml) and [`libraries-v8-release.yaml`](../libraries-v8-release.yaml) for the exact commit SHAs used.
+
+**Succession**
+
+| Extension |
+| --------- |
+| Biomass Succession |
+| ForCS Succession |
+| NECN Succession |
+| PnET Succession |
+
+**Disturbance and other**
+
+| Extension |
+| --------- |
+| Base BDA |
+| Base Fire |
+| Base Wind |
+| Biomass Harvest |
+| Biomass Hurricane |
+| Dynamic Biomass Fuels |
+| Dynamic Fire System |
+| Land Use Plus |
+| LinearWind |
+| Social Climate Fire |
+| Forest Roads Simulation |
+| Magic Harvest |
+
+**Output**
+
+| Extension |
+| --------- |
+| Output Biomass |
+| Output Biomass By Age |
+| Output Biomass Community |
+| Output Biomass (PnET) |
+| Output Biomass Reclass |
+| Output Cohort Statistics |
+| Output Max Species Age |
+| Output Wildlife Habitat |
+| Local Habitat Suitability Output |
+
+## Enhancements over `landis-ii-v8-linux`
+
+This image supersedes `Clean_Docker_LANDIS-II_8_AllExtensions` with the following improvements:
+
+- Ubuntu 24.04 (noble) base image instead of 22.04 (jammy);
+- `dotnet` installed from the `apt` repositories;
+- LANDIS-II placed at `/opt/landis-ii` (standard location for third-party software);
+- extension and library versions defined in shared `*.yaml` files, not hardcoded in the Dockerfile;
+- shared `.csproj` files for Forest Roads and Magic Harvest extensions (`extension_files/`);
+- build scripts rewritten in `bash`, shared in `scripts/`, reusable across image flavours;
+- `yq` used to parse yaml; `xmlstarlet` used to edit `.csproj` XML;
+- shared tests (`tests/`) run as part of the build;
 
 ## Build the image
 
-### Linux (bash)
+Build from the repository root so that shared files (`extension_files/`, `scripts/`, `*.yaml`) are available.
+
+### Linux / macOS (bash)
 
 ```shell
 cd ~/Tool-Docker-Apptainer
 
 docker build . \
   -f Docker-LANDIS-II-v8-release/Dockerfile \
-  -t landis-ii-8-release:release
+  -t landis-ii-v8-release:release
 ```
 
-### Windows (Powershell)
+### Windows (PowerShell)
 
 ```shell
 cd ~/Tool-Docker-Apptainer
 
 docker build . `
   -f Docker-LANDIS-II-v8-release/Dockerfile `
-  -t landis-ii-8-release:release
+  -t landis-ii-v8-release:release
 ```
 
-## Run a container
+## Run a locally built container
+
+Replace `landis-ii-v8-release:release` with `ghcr.io/landis-ii-foundation/landis-ii-v8-release:main` if you pulled the pre-built image instead.
 
 ### Interactive container
 
-#### Linux (bash)
+#### Linux / macOS (bash)
 
 ```shell
 docker run -it \
   --cpus=4 \
   --memory=64g \
-  --mount type=bind,src="<SCENARIO_FOLDER_FULL_PATH_ON_COMPUTER>",dst=/scenarioFolder \
+  --mount type=bind,src="/path/to/your/scenario",dst=/scenarioFolder \
   --name landis01 \
-  landis-ii-8-release:release
+  landis-ii-v8-release:release
 ```
 
-#### Windows (Powershell)
+#### Windows (PowerShell)
 
 ```shell
 docker run -it `
   --cpus=4 `
   --memory=64g `
-  --mount type=bind,src="<SCENARIO_FOLDER_FULL_PATH_ON_COMPUTER>",dst=/scenarioFolder `
+  --mount type=bind,src="C:\path\to\your\scenario",dst=/scenarioFolder `
   --name landis01 `
-  landis-ii-8-release:release
+  landis-ii-v8-release:release
 ```
 
-### Non-interactive container
+### Non-interactive container (run a single simulation)
 
-E.g., run a single LANDIS-II simulation
-
-#### Linux (bash)
+#### Linux / macOS (bash)
 
 ```shell
-docker run \
+docker run --rm \
   --cpus=4 \
   --memory=64g \
-  --mount type=bind,src="<SCENARIO_FOLDER_FULL_PATH_ON_COMPUTER>",dst=/scenarioFolder \
+  --mount type=bind,src="/path/to/your/scenario",dst=/scenarioFolder \
   --name landis01 \
-  landis-ii-8:release /bin/sh -c "cd /scenarioFolder && dotnet \$LANDIS_CONSOLE scenario.txt"
+  landis-ii-v8-release:release \
+  /bin/sh -c "cd /scenarioFolder && dotnet \$LANDIS_CONSOLE scenario.txt"
 ```
 
-#### Windows (Powershell)
+#### Windows (PowerShell)
 
 ```shell
-docker run `
+docker run --rm `
   --cpus=4 `
   --memory=64g `
-  --mount type=bind,src="<SCENARIO_FOLDER_FULL_PATH_ON_COMPUTER>",dst=/scenarioFolder `
+  --mount type=bind,src="C:\path\to\your\scenario",dst=/scenarioFolder `
   --name landis01 `
-  landis-ii-8:release /bin/sh -c "cd /scenarioFolder && dotnet `$LANDIS_CONSOLE scenario.txt"
+  landis-ii-v8-release:release `
+  /bin/sh -c "cd /scenarioFolder && dotnet `$LANDIS_CONSOLE scenario.txt"
 ```
-

--- a/README.md
+++ b/README.md
@@ -48,9 +48,30 @@ Simply select an image that best suits your needs - you can use "as is" or simpl
 > However, we recommend that you familiarize yourself with the rest of the instructions to learn
 > how to edit and customize them for your own research purposes.
 
+### Which image should I use?
+
+**New to Docker? Start here:** download and use a pre-built image — no build step required (see [Get a pre-built image](#-get-a-pre-built-image) below).
+
+| Goal | Recommended image |
+| ---- | ----------------- |
+| Run LANDIS-II v8 simulations | `landis-ii-v8-release` |
+| Run LANDIS-II v8 with UCL v2 extensions | `landis-ii-v8-uclv2-release` |
+| Run LANDIS-II v8 with R and RStudio | `landis-ii-v8-rstudio` |
+| Run LANDIS-II v8 with R (no RStudio) | `landis-ii-v8-r` |
+| Run LANDIS-II v7 simulations | `landis-ii-v7-release` |
+| Use the latest (potentially unstable) extension commits | `landis-ii-v8-latest` |
+
+**v7 vs v8?**
+- Use **v8** unless you have a specific reason not to — it is the current recommended version.
+- Use **v7** if your scenario is not yet compatible with v8, or if you need extensions not available in v8 (e.g., BFOLDS Fire, DGS Succession, Biomass Browse). See the UCL bug warning at the top of this page for v8 caveats.
+
+**`landis-ii-v8-release` vs `landis-ii-v8-uclv2-release`?**
+- **`landis-ii-v8-release`** includes the full set of v8-compatible extensions. Some extensions have a known bug in the Universal Cohort Library (UCL) — see the warning at the top of this page.
+- **`landis-ii-v8-uclv2-release`** includes extensions updated for UCL v2, which fixes that bug. Some extensions are still pending update and are not yet included in this image.
+
 ### Generic images
 
-These images provide a minimal LANDIS-II installation, including GDAL, plus a python installation.
+These images provide a minimal LANDIS-II installation, including GDAL, plus a Python installation.
 
 > 💡 The `Clean_Docker_*` images hardcode the extensions and their specific commits directly in the Dockerfile,
 > whereas the others refer to a `.yaml` file (e.g., [`extensions-v8-release.yaml`](extensions-v8-release.yaml)) to define the versions used.
@@ -61,27 +82,27 @@ These images provide a minimal LANDIS-II installation, including GDAL, plus a py
 
 | Image name             | Subdirectory                               | Description                                         |
 | ---------------------- | ------------------------------------------ | --------------------------------------------------- |
-| `landis-ii-v7-linux`   | `Clean_Docker_LANDIS-II_7_AllExtensions/`  | LANDIS-II v7 (Ubuntu 22.04); fixed versions of v7-compatible extensions; **superseded by `landis-ii-v7-release`** |
 | `landis-ii-v7-release` | `Docker-LANDIS-II-v7-release/`             | LANDIS-II v7 (Ubuntu 22.04); [fixed versions of v7-compatible extensions](extensions-v7-release.yaml) |
+| ~~`landis-ii-v7-linux`~~ | ~~`Clean_Docker_LANDIS-II_7_AllExtensions/`~~ | **Deprecated** — superseded by `landis-ii-v7-release` |
 
 **LANDIS-II v8 images**
 
 | Image name             | Subdirectory                               | Description                                         |
 | ---------------------- | ------------------------------------------ | --------------------------------------------------- |
-| `landis-ii-v8-linux`   | `Clean_Docker_LANDIS-II_8_AllExtensions/`  | LANDIS-II v8 (Ubuntu 22.04); fixed versions of v8 extensions; **superseded by `landis-ii-v8-release`** |
 | `landis-ii-v8-release` | `Docker-LANDIS-II-v8-release/`             | LANDIS-II v8 (Ubuntu 24.04); [fixed versions of v8 extensions](extensions-v8-release.yaml) |
-| `landis-ii-v8-uclv2-release` | `Docker-LANDIS-II-v8-UCL2-release/` | LANDIS-II v8 (Ubuntu 24.04); [fixed versions of v8 extensions](extensions-v8-UCLv2-release.yaml) |
+| `landis-ii-v8-uclv2-release` | `Docker-LANDIS-II-v8-UCL2-release/` | LANDIS-II v8 (Ubuntu 24.04); [extensions updated for UCL v2](extensions-v8-UCL2-release.yaml) |
+| ~~`landis-ii-v8-linux`~~ | ~~`Clean_Docker_LANDIS-II_8_AllExtensions/`~~ | **Deprecated** — superseded by `landis-ii-v8-release` |
 
-### R/Rstudio images
+### R/RStudio images
 
-These images are based on the generic images and add R and/or a running Rstudio Server instance.
+These images are based on the generic images and add R and/or a running RStudio Server instance.
 
 **LANDIS-II v8 images**
 
 | Image name             | Subdirectory                               | Description                                         |
 | ---------------------- | ------------------------------------------ | --------------------------------------------------- |
-| `landis-ii-v8-r`       | `Docker-LANDIS-II-v8-release-R/`           | LANDIS-II v8 (Ubuntu 24.04); [fixed versions of v8 extensions](extensions-v8-release.yaml); |
-| `landis-ii-v8-rstudio` | `Docker-LANDIS-II-v8-release-Rstudio/`     | LANDIS-II v8 (Ubuntu 24.04); [fixed versions of v8 extensions](extensions-v8-release.yaml); Rstudio Server |
+| `landis-ii-v8-r`       | `Docker-LANDIS-II-v8-R/`                   | LANDIS-II v8 (Ubuntu 24.04); [fixed versions of v8 extensions](extensions-v8-release.yaml); R 4.6.0 |
+| `landis-ii-v8-rstudio` | `Docker-LANDIS-II-v8-Rstudio/`             | LANDIS-II v8 (Ubuntu 24.04); [fixed versions of v8 extensions](extensions-v8-release.yaml); R 4.6.0; RStudio Server |
 
 ### Other custom images
 
@@ -91,25 +112,32 @@ These images are based on the generic images and add R and/or a running Rstudio 
 | ---------------------- | ------------------------------------------ | --------------------------------------------------- |
 | `landis-ii-v8-latest`  | `Clean_Docker_LANDIS-II_8_Latest_Commits/` | LANDIS-II v8 (Ubuntu 22.04); latest versions of v8 extensions; `miniconda` and [iRods](https://irods.org/) |
 
-### 📥 Get a prebuilt image
+### 📥 Get a pre-built image
 
-**Authenticate with the GitHub Container Registry:**
+Pre-built images are publicly available on the GitHub Container Registry and **do not require authentication** to download.
 
-1. Setup a personal access token following [these instructions](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic);
+```shell
+## replace <imagename> with one from the tables above (e.g., landis-ii-v8-release)
+docker pull ghcr.io/landis-ii-foundation/<imagename>:main
+```
 
-2. Login with Docker:
+> 💡 You can also skip the `docker pull` step entirely: if you use an image name in a `docker run` command and the image is not already on your computer, Docker will download it automatically.
+
+<details>
+<summary>Authentication (optional — only needed for private images)</summary>
+
+If you need to access a private image, you must authenticate with GitHub first.
+
+1. Set up a personal access token following [these instructions](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic);
+
+2. Log in with Docker:
 
     ```shell
     export GHCR_PAT=YOUR_TOKEN
     echo $GHCR_PAT | docker login ghcr.io -u USERNAME --password-stdin
     ```
 
-**Download the image:**
-
-```shell
-## replace <imagename> with one from above
-docker pull ghcr.io/landis-ii-foundation/<imagename>:main
-```
+</details>
 
 ### 📦 Building the docker image containing LANDIS-II
 
@@ -154,7 +182,7 @@ docker pull ghcr.io/landis-ii-foundation/<imagename>:main
 
 
 > [!WARNING]
-> You may get the occaisional error during the build that are due to internet connection issues.
+> You may get the occasional error during the build that are due to internet connection issues.
 > For example, when the build is downloading files from GitHub it may error with messages similar to:
 > 
 > ```shell
@@ -168,7 +196,7 @@ docker pull ghcr.io/landis-ii-foundation/<imagename>:main
 > NOTE: Using a VPN may create additional issues with some commands.
 > If you encounter errors with a VPN enabled, you can try disabling your VPN and retrying the build.
 
-### 📝 (Optional) Customizing the Docker image image with R packages, Python packages, or anything else
+### 📝 (Optional) Customizing the Docker image with R packages, Python packages, or anything else
 
 The Docker images we have created contain the minimal set of the components necessary to run
 LANDIS-II in the container, and cover several important use cases (but not all!).
@@ -297,7 +325,7 @@ dotnet $LANDIS_CONSOLE scenario.txt
 - `dotnet` is the Linux program that allows us to run LANDIS-II on Linux, since it's coded in `C#` (a programming language made by Microsoft);
 - `$LANDIS_CONSOLE` is an environment variable that contains the location of the LANDIS-II program
   in the container (in `/bin/LANDIS_Linux/build/Release/Landis.Console.dll`);
-- `scenario.txt` is the name of your scenario fiMY_LANDIS_CONTAINER_NAMEle;
+- `scenario.txt` is the name of your scenario file;
 
 As such, if you want to run LANDIS-II through an interactive container :
 


### PR DESCRIPTION
## Summary

- **Main README:** adds a "Which image should I use?" decision guide
  (quick-reference table, v7 vs v8 guidance, `release` vs `uclv2-release`
  guidance); marks the deprecated `-linux` images with strikethrough;
  simplifies the pull instructions — public images require no authentication
  (confirmed in #20); moves auth docs to a collapsible `<details>` block;
  fixes subdirectory paths for R/RStudio images in the table; fixes several
  typos (duplicate word, misspelling, `MY_LANDIS_CONTAINER_NAME` embedded
  in body text).

- **Active image READMEs** (`v7-release`, `v8-release`, `v8-UCL2`,
  `v8-R`, `v8-Rstudio`): adds a "Quick start: use the pre-built image"
  section at the top for users who don't need to build locally; adds
  included-extensions tables so users can see what's available without
  reading the yaml files; fixes broken image names in `docker run`
  commands; adds Windows PowerShell instructions where they were missing;
  adds `--rm` to one-shot run examples.

- **UCL2 README:** fixes an incorrect yaml file reference (`extensions-v8-release.yaml`
  → `extensions-v8-UCL2-release.yaml`); documents which extensions are
  still pending UCL v2 updates and why they are absent from the image.

- **Legacy READMEs** (`Clean_Docker_LANDIS-II_7_AllExtensions`,
  `Clean_Docker_LANDIS-II_8_AllExtensions`): adds GitHub-style `[!WARNING]`
  deprecation notices pointing users to the replacement images.

## Test plan

- [ ] Review rendered Markdown in the GitHub preview for all changed README files
- [ ] Confirm deprecated image rows render with strikethrough in the main README tables
- [ ] Confirm `<details>` auth block collapses correctly on GitHub
- [ ] Confirm all `docker pull` / `docker run` commands reference correct image names

Closes #20

@Klemet — tagging you for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)