### PR TITLE
prevent CRLF line endings from breaking shell scripts on Windows builds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Enforce LF line endings for shell scripts regardless of git autocrlf setting.
+# Prevents CRLF issues when building Docker images on Windows.
+*.sh text eol=lf

--- a/Clean_Docker_LANDIS-II_7_AllExtensions/Dockerfile
+++ b/Clean_Docker_LANDIS-II_7_AllExtensions/Dockerfile
@@ -87,7 +87,8 @@ COPY ./files_to_help_compilation/editing_csproj_LANDIS-II_files.py $LANDIS_DIR
 
 # Transfering the sh script that allows us to only download one folder from one commit from github
 COPY ./files_to_help_compilation/downloadSpecificGitCommitAndFolder.sh $LANDIS_DIR
-RUN chmod +x $LANDIS_DIR/downloadSpecificGitCommitAndFolder.sh
+RUN sed -i 's/\r$//' $LANDIS_DIR/downloadSpecificGitCommitAndFolder.sh \
+    && chmod +x $LANDIS_DIR/downloadSpecificGitCommitAndFolder.sh
 
 ###### COMPILING AND REGISTERING EXTENSIONS 
 # INFO: The files necessary for the compilation are downloaded through the script downloadSpecificGitCommitAndFolder.sh

--- a/Clean_Docker_LANDIS-II_8_AllExtensions/Dockerfile
+++ b/Clean_Docker_LANDIS-II_8_AllExtensions/Dockerfile
@@ -82,7 +82,8 @@ COPY ./files_to_help_compilation/editing_csproj_LANDIS-II_files.py $LANDIS_FOLDE
 
 # Transfering the sh script that allows us to only download one folder from one commit from github
 COPY ./files_to_help_compilation/downloadSpecificGitCommitAndFolder.sh $LANDIS_FOLDER
-RUN chmod +x $LANDIS_FOLDER/downloadSpecificGitCommitAndFolder.sh
+RUN sed -i 's/\r$//' $LANDIS_FOLDER/downloadSpecificGitCommitAndFolder.sh \
+    && chmod +x $LANDIS_FOLDER/downloadSpecificGitCommitAndFolder.sh
 
 ###### COMPILING AND REGISTERING EXTENSIONS
 # INFO: The files necessary for the compilation are downloaded through the script downloadSpecificGitCommitAndFolder.sh

--- a/Clean_Docker_LANDIS-II_8_Latest_Commits/Dockerfile
+++ b/Clean_Docker_LANDIS-II_8_Latest_Commits/Dockerfile
@@ -313,6 +313,7 @@ EXPOSE 7681
 
 # changes tmux layout while running
 COPY entry.sh /bin
+RUN sed -i 's/\r$//' /bin/entry.sh
 RUN echo 'set-option -g status off' >> ~/.tmux.conf
 
 # add iRODS iCommands to user profile as JSON

--- a/Docker-LANDIS-II-v7-release/Dockerfile
+++ b/Docker-LANDIS-II-v7-release/Dockerfile
@@ -84,7 +84,8 @@ ENV LANDIS_EXT_TOOL="$LANDIS_REL_DIR/Landis.Extensions.dll"
 WORKDIR $LANDIS_DIR
 
 COPY scripts $LANDIS_DIR/scripts
-RUN chmod a+x $LANDIS_DIR/scripts/*.sh
+RUN sed -i 's/\r$//' $LANDIS_DIR/scripts/*.sh \
+    && chmod a+x $LANDIS_DIR/scripts/*.sh
 
 ################################################################
 ## COMPILING LANDIS-II AND EXTENSIONS

--- a/Docker-LANDIS-II-v8-R/Dockerfile
+++ b/Docker-LANDIS-II-v8-R/Dockerfile
@@ -68,7 +68,8 @@ ENV LANDIS_EXT_TOOL="$LANDIS_REL_DIR/Landis.Extensions.dll"
 WORKDIR $LANDIS_DIR
 
 COPY scripts $LANDIS_DIR/scripts
-RUN chmod a+x $LANDIS_DIR/scripts/*.sh
+RUN sed -i 's/\r$//' $LANDIS_DIR/scripts/*.sh \
+    && chmod a+x $LANDIS_DIR/scripts/*.sh
 
 ################################################################
 ## COMPILING LANDIS-II AND EXTENSIONS

--- a/Docker-LANDIS-II-v8-Rstudio/Dockerfile
+++ b/Docker-LANDIS-II-v8-Rstudio/Dockerfile
@@ -65,7 +65,8 @@ ENV LANDIS_EXT_TOOL="$LANDIS_REL_DIR/Landis.Extensions.dll"
 WORKDIR $LANDIS_DIR
 
 COPY scripts $LANDIS_DIR/scripts
-RUN chmod a+x $LANDIS_DIR/scripts/*.sh
+RUN sed -i 's/\r$//' $LANDIS_DIR/scripts/*.sh \
+    && chmod a+x $LANDIS_DIR/scripts/*.sh
 
 ################################################################
 ## COMPILING LANDIS-II AND EXTENSIONS

--- a/Docker-LANDIS-II-v8-UCL2-release/Dockerfile
+++ b/Docker-LANDIS-II-v8-UCL2-release/Dockerfile
@@ -68,7 +68,8 @@ ENV LANDIS_EXT_TOOL="$LANDIS_REL_DIR/Landis.Extensions.dll"
 WORKDIR $LANDIS_DIR
 
 COPY scripts $LANDIS_DIR/scripts
-RUN chmod a+x $LANDIS_DIR/scripts/*.sh
+RUN sed -i 's/\r$//' $LANDIS_DIR/scripts/*.sh \
+    && chmod a+x $LANDIS_DIR/scripts/*.sh
 
 ################################################################
 ## COMPILING LANDIS-II AND EXTENSIONS

--- a/Docker-LANDIS-II-v8-release/Dockerfile
+++ b/Docker-LANDIS-II-v8-release/Dockerfile
@@ -68,7 +68,8 @@ ENV LANDIS_EXT_TOOL="$LANDIS_REL_DIR/Landis.Extensions.dll"
 WORKDIR $LANDIS_DIR
 
 COPY scripts $LANDIS_DIR/scripts
-RUN chmod a+x $LANDIS_DIR/scripts/*.sh
+RUN sed -i 's/\r$//' $LANDIS_DIR/scripts/*.sh \
+    && chmod a+x $LANDIS_DIR/scripts/*.sh
 
 ################################################################
 ## COMPILING LANDIS-II AND EXTENSIONS


### PR DESCRIPTION
Fixes #41 

Windows git clients with autocrlf=true convert LF -> CRLF on checkout, causing shell scripts to fail inside Linux containers with "/bin/bash^M: bad interpreter".

Add .gitattributes to enforce LF for all *.sh files going forward, and add `sed -i 's/\r$//'` before each chmod step in all 8 Dockerfiles as a belt-and-suspenders fix for repos already cloned without the gitattributes enforcement. Uses sed (always present in Debian/Ubuntu base images) rather than dos2unix to avoid any extra package installs.

@Klemet can you please review?