### PR TITLE
feat: add Ubuntu 26.04 (resolute) support to LANDIS-II v8 images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,21 +31,58 @@ jobs:
           # - dockercontext: ./Clean_Docker_LANDIS-II_8_Latest_Commits
           #   dockerfile: ./Clean_Docker_LANDIS-II_8_Latest_Commits/Dockerfile
           #   image: ghcr.io/${{ github.repository_owner }}/landis-ii-v8-latest
+
+          ## v7 — stays on Ubuntu 22.04 permanently (.NET 2.2 / libssl1.1 requirement)
           - dockercontext: .
             dockerfile: ./Docker-LANDIS-II-v7-release/Dockerfile
             image: ghcr.io/${{ github.repository_owner }}/landis-ii-v7-release
+            ubuntu_version: "22.04"
+            is_latest: "true"
+            build_ubuntu_arg: "false"
+
+          ## v8-release — Ubuntu 24.04 and 26.04
           - dockercontext: .
             dockerfile: ./Docker-LANDIS-II-v8-release/Dockerfile
             image: ghcr.io/${{ github.repository_owner }}/landis-ii-v8-release
+            ubuntu_version: "24.04"
+            is_latest: "false"
+            build_ubuntu_arg: "true"
+          - dockercontext: .
+            dockerfile: ./Docker-LANDIS-II-v8-release/Dockerfile
+            image: ghcr.io/${{ github.repository_owner }}/landis-ii-v8-release
+            ubuntu_version: "26.04"
+            is_latest: "true"
+            build_ubuntu_arg: "true"
+
+          ## v8-UCL2-release — Ubuntu 24.04 and 26.04
           - dockercontext: .
             dockerfile: ./Docker-LANDIS-II-v8-UCL2-release/Dockerfile
             image: ghcr.io/${{ github.repository_owner }}/landis-ii-v8-uclv2-release
+            ubuntu_version: "24.04"
+            is_latest: "false"
+            build_ubuntu_arg: "true"
+          - dockercontext: .
+            dockerfile: ./Docker-LANDIS-II-v8-UCL2-release/Dockerfile
+            image: ghcr.io/${{ github.repository_owner }}/landis-ii-v8-uclv2-release
+            ubuntu_version: "26.04"
+            is_latest: "true"
+            build_ubuntu_arg: "true"
+
+          ## v8-R — rocker/r-ver:4.6.0 is Ubuntu 24.04; revisit when R 4.6.1 ships (~June 2026)
           - dockercontext: .
             dockerfile: ./Docker-LANDIS-II-v8-R/Dockerfile
             image: ghcr.io/${{ github.repository_owner }}/landis-ii-v8-R
+            ubuntu_version: "24.04"
+            is_latest: "true"
+            build_ubuntu_arg: "false"
+
+          ## v8-Rstudio — rocker/geospatial:4.6.0 is Ubuntu 24.04; revisit when R 4.6.1 ships (~June 2026)
           - dockercontext: .
             dockerfile: ./Docker-LANDIS-II-v8-Rstudio/Dockerfile
             image: ghcr.io/${{ github.repository_owner }}/landis-ii-v8-Rstudio
+            ubuntu_version: "24.04"
+            is_latest: "true"
+            build_ubuntu_arg: "false"
 
     ## Set the permissions granted to the `GITHUB_TOKEN` for the actions in this job
     permissions:
@@ -70,11 +107,25 @@ jobs:
 
       ## Extract metadata (tags, labels) for Docker
       ## https://github.com/docker/metadata-action
+      ##
+      ## Tag scheme:
+      ##   :ubuntu-<version>  — pinnable OS-specific tag (all entries)
+      ##   :ubuntu-latest     — most recent Ubuntu LTS build (is_latest entries only)
+      ##   :latest            — alias for :ubuntu-latest (is_latest entries only)
+      ##   :main              — alias for :ubuntu-latest, kept for backwards compatibility (is_latest entries only)
+      ##
+      ## For images with multiple Ubuntu versions (v8-release, v8-UCL2-release), :ubuntu-latest/:latest/:main
+      ## are only pushed by the is_latest entry to avoid a race condition between parallel CI jobs.
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
         with:
           images: ${{ matrix.image }}
+          tags: |
+            type=ref,event=branch,enable=${{ matrix.is_latest == 'true' }}
+            type=raw,value=ubuntu-${{ matrix.ubuntu_version }}
+            type=raw,value=ubuntu-latest,enable=${{ matrix.is_latest == 'true' }}
+            type=raw,value=latest,enable=${{ matrix.is_latest == 'true' }}
 
       ## Build and push Docker image with Buildx (don't push on PR)
       ## https://github.com/docker/build-push-action
@@ -87,6 +138,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ matrix.build_ubuntu_arg == 'true' && format('UBUNTU_VERSION={0}', matrix.ubuntu_version) || '' }}
 
       ## Generates an artifact attestation for image build provenance
       ## https://github.com/actions/attest-build-provenance

--- a/Docker-LANDIS-II-v7-release/README.md
+++ b/Docker-LANDIS-II-v7-release/README.md
@@ -8,8 +8,11 @@ LANDIS-II v7 (Ubuntu 22.04) with a fixed, tested set of extensions defined in [`
 ## Quick start: use the pre-built image
 
 ```shell
-docker pull ghcr.io/landis-ii-foundation/landis-ii-v7-release:main
+docker pull ghcr.io/landis-ii-foundation/landis-ii-v7-release:ubuntu-latest
 ```
+
+> 💡 **Tags:** `:ubuntu-latest`, `:latest`, and `:main` all point to the same image (Ubuntu 22.04 — the only supported OS for v7).
+> `:main` is retained for backwards compatibility.
 
 Then run a simulation (replace the path with your scenario folder):
 
@@ -19,7 +22,7 @@ docker run --rm \
   --cpus=4 \
   --memory=64g \
   --mount type=bind,src="/path/to/your/scenario",dst=/scenarioFolder \
-  ghcr.io/landis-ii-foundation/landis-ii-v7-release:main \
+  ghcr.io/landis-ii-foundation/landis-ii-v7-release:ubuntu-latest \
   /bin/sh -c "cd /scenarioFolder && dotnet \$LANDIS_CONSOLE scenario.txt"
 
 ## Windows (PowerShell)
@@ -27,7 +30,7 @@ docker run --rm `
   --cpus=4 `
   --memory=64g `
   --mount type=bind,src="C:\path\to\your\scenario",dst=/scenarioFolder `
-  ghcr.io/landis-ii-foundation/landis-ii-v7-release:main `
+  ghcr.io/landis-ii-foundation/landis-ii-v7-release:ubuntu-latest `
   /bin/sh -c "cd /scenarioFolder && dotnet `$LANDIS_CONSOLE scenario.txt"
 ```
 
@@ -120,7 +123,7 @@ docker build . `
 
 ## Run a locally built container
 
-Replace `landis-ii-v7-release:release` with `ghcr.io/landis-ii-foundation/landis-ii-v7-release:main` if you pulled the pre-built image instead.
+Replace `landis-ii-v7-release:release` with `ghcr.io/landis-ii-foundation/landis-ii-v7-release:ubuntu-latest` if you pulled the pre-built image instead.
 
 ### Interactive container
 

--- a/Docker-LANDIS-II-v8-R/README.md
+++ b/Docker-LANDIS-II-v8-R/README.md
@@ -12,8 +12,11 @@ LANDIS-II v8 with R 4.6.0, built on [`rocker/r-ver:4.6.0`](https://rocker-projec
 ## Quick start: use the pre-built image
 
 ```shell
-docker pull ghcr.io/landis-ii-foundation/landis-ii-v8-r:main
+docker pull ghcr.io/landis-ii-foundation/landis-ii-v8-r:ubuntu-latest
 ```
+
+> 💡 **Tags:** `:ubuntu-latest`, `:latest`, and `:main` all point to the same image (Ubuntu 24.04 via `rocker/r-ver:4.6.0`).
+> `:main` is retained for backwards compatibility.
 
 Run an interactive R session with your project files available inside the container:
 
@@ -23,7 +26,7 @@ docker run -it --rm \
   --cpus=4 \
   --memory=64g \
   --mount type=bind,src="/path/to/your/project",dst=/home/project \
-  ghcr.io/landis-ii-foundation/landis-ii-v8-r:main \
+  ghcr.io/landis-ii-foundation/landis-ii-v8-r:ubuntu-latest \
   R
 
 ## Windows (PowerShell)
@@ -31,7 +34,7 @@ docker run -it --rm `
   --cpus=4 `
   --memory=64g `
   --mount type=bind,src="C:\path\to\your\project",dst=/home/project `
-  ghcr.io/landis-ii-foundation/landis-ii-v8-r:main `
+  ghcr.io/landis-ii-foundation/landis-ii-v8-r:ubuntu-latest `
   R
 ```
 

--- a/Docker-LANDIS-II-v8-Rstudio/README.md
+++ b/Docker-LANDIS-II-v8-Rstudio/README.md
@@ -13,8 +13,11 @@ LANDIS-II v8 with R 4.6.0 and RStudio Server, built on [`rocker/geospatial:4.6.0
 ## Quick start: use the pre-built image
 
 ```shell
-docker pull ghcr.io/landis-ii-foundation/landis-ii-v8-rstudio:main
+docker pull ghcr.io/landis-ii-foundation/landis-ii-v8-rstudio:ubuntu-latest
 ```
+
+> 💡 **Tags:** `:ubuntu-latest`, `:latest`, and `:main` all point to the same image (Ubuntu 24.04 via `rocker/geospatial:4.6.0`).
+> `:main` is retained for backwards compatibility.
 
 ## Run a container
 
@@ -38,7 +41,7 @@ docker run -d -it \
   -p 127.0.0.1:8080:8787 \
   --mount type=bind,source="/path/to/your/project",target=/home/rstudio/project \
   --name landis01 \
-  ghcr.io/landis-ii-foundation/landis-ii-v8-rstudio:main
+  ghcr.io/landis-ii-foundation/landis-ii-v8-rstudio:ubuntu-latest
 ```
 
 ### Windows (PowerShell)
@@ -51,7 +54,7 @@ docker run -d -it `
   -p 127.0.0.1:8080:8787 `
   --mount type=bind,source="C:\path\to\your\project",target=/home/rstudio/project `
   --name landis01 `
-  ghcr.io/landis-ii-foundation/landis-ii-v8-rstudio:main
+  ghcr.io/landis-ii-foundation/landis-ii-v8-rstudio:ubuntu-latest
 ```
 
 > **Note for Windows users:** `$(id -u)` and `$(id -g)` are Linux/macOS shell substitutions and are not available in PowerShell. Omitting `USERID`/`GROUPID` uses the defaults (1000); if you encounter permission issues on mounted files, set them explicitly (e.g., `-e USERID=1000`).

--- a/Docker-LANDIS-II-v8-UCL2-release/Dockerfile
+++ b/Docker-LANDIS-II-v8-UCL2-release/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:24.04
+ARG UBUNTU_VERSION=24.04
+FROM ubuntu:${UBUNTU_VERSION}
+ARG UBUNTU_VERSION   ## must re-declare after FROM to stay in scope
 
 LABEL org.opencontainers.image.authors="clem.hardy@pm.me; achubaty@for-cast.ca;"
 
@@ -16,6 +18,10 @@ ENV LC_ALL=C.UTF-8
 ## - python needed for Magic Harvest;
 ## - `xmlstarlet` used to edit xml in .csproj files;
 RUN apt-get update && apt-get upgrade -y \
+  && apt-get install -y software-properties-common \
+  && if [ "${UBUNTU_VERSION}" = "26.04" ]; then \
+       add-apt-repository ppa:dotnet/backports && apt-get update; \
+     fi \
   && apt-get install -y \
     dotnet-sdk-8.0 \
     gdal-bin \
@@ -25,14 +31,22 @@ RUN apt-get update && apt-get upgrade -y \
     libpng16-16t64 \
     mono-utils \
     nano \
-    pip \
     python3 \
+    python3-pip \
     python-is-python3 \
-    software-properties-common \
     vim \
     wget \
     xmlstarlet \
   && apt-get clean -y && rm -rf /var/lib/apt/lists/* ## clean up to save space
+
+## Ubuntu 26.04 changed SO names for three libraries that Gdal.Core NuGet's bundled libgdal.so.20
+## was compiled against: libxml2 (.so.2 → .so.16), libicuuc/libicudata (.so.74 → .so.78)
+RUN if [ "${UBUNTU_VERSION}" = "26.04" ]; then \
+      ln -s /usr/lib/x86_64-linux-gnu/libxml2.so.16 /usr/lib/x86_64-linux-gnu/libxml2.so.2 \
+      && ln -s /usr/lib/x86_64-linux-gnu/libicuuc.so.78 /usr/lib/x86_64-linux-gnu/libicuuc.so.74 \
+      && ln -s /usr/lib/x86_64-linux-gnu/libicudata.so.78 /usr/lib/x86_64-linux-gnu/libicudata.so.74 \
+      && ldconfig; \
+    fi
 
 ## install yq (used to parse yaml files) from source
 RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq \

--- a/Docker-LANDIS-II-v8-UCL2-release/README.md
+++ b/Docker-LANDIS-II-v8-UCL2-release/README.md
@@ -1,6 +1,6 @@
 # Docker-LANDIS-II-v8-UCLv2-release
 
-LANDIS-II v8 (Ubuntu 24.04) with extensions updated for **Universal Cohort Library (UCL) v2**, defined in [`extensions-v8-UCL2-release.yaml`](../extensions-v8-UCL2-release.yaml). UCL v2 fixes a significant biomass-removal bug present in earlier extensions — see the [warning in the main README](../README.md) for details.
+LANDIS-II v8 (Ubuntu 24.04 and 26.04) with extensions updated for **Universal Cohort Library (UCL) v2**, defined in [`extensions-v8-UCL2-release.yaml`](../extensions-v8-UCL2-release.yaml). UCL v2 fixes a significant biomass-removal bug present in earlier extensions — see the [warning in the main README](../README.md) for details.
 
 > **Note:** Some extensions are still pending UCL v2 updates and are therefore not included. Extensions not yet updated include: PnET Succession, Base BDA, Dynamic Biomass Fuels, Dynamic Fire System, LinearWind, Forest Roads Simulation, Magic Harvest, Output Biomass (PnET), Output Wildlife Habitat, and Local Habitat Suitability Output. Use [`landis-ii-v8-release`](../Docker-LANDIS-II-v8-release/) if you need those extensions.
 
@@ -10,8 +10,11 @@ LANDIS-II v8 (Ubuntu 24.04) with extensions updated for **Universal Cohort Libra
 ## Quick start: use the pre-built image
 
 ```shell
-docker pull ghcr.io/landis-ii-foundation/landis-ii-v8-uclv2-release:main
+docker pull ghcr.io/landis-ii-foundation/landis-ii-v8-uclv2-release:ubuntu-latest
 ```
+
+> 💡 **Tags:** `:ubuntu-latest`, `:latest`, and `:main` all point to the most recent Ubuntu LTS build (currently Ubuntu 26.04).
+> Use `:ubuntu-24.04` or `:ubuntu-26.04` to pin to a specific OS version.
 
 Then run a simulation (replace the path with your scenario folder):
 
@@ -21,7 +24,7 @@ docker run --rm \
   --cpus=4 \
   --memory=64g \
   --mount type=bind,src="/path/to/your/scenario",dst=/scenarioFolder \
-  ghcr.io/landis-ii-foundation/landis-ii-v8-uclv2-release:main \
+  ghcr.io/landis-ii-foundation/landis-ii-v8-uclv2-release:ubuntu-latest \
   /bin/sh -c "cd /scenarioFolder && dotnet \$LANDIS_CONSOLE scenario.txt"
 
 ## Windows (PowerShell)
@@ -29,7 +32,7 @@ docker run --rm `
   --cpus=4 `
   --memory=64g `
   --mount type=bind,src="C:\path\to\your\scenario",dst=/scenarioFolder `
-  ghcr.io/landis-ii-foundation/landis-ii-v8-uclv2-release:main `
+  ghcr.io/landis-ii-foundation/landis-ii-v8-uclv2-release:ubuntu-latest `
   /bin/sh -c "cd /scenarioFolder && dotnet `$LANDIS_CONSOLE scenario.txt"
 ```
 
@@ -77,7 +80,7 @@ This image builds on `Docker-LANDIS-II-v8-release` with the following addition:
 
 All other enhancements from `Docker-LANDIS-II-v8-release` also apply:
 
-- Ubuntu 24.04 (noble) base image;
+- Ubuntu 24.04 (noble) and 26.04 (resolute) base images, selectable via `--build-arg UBUNTU_VERSION=<version>`; defaults to 24.04;
 - `dotnet` installed from the `apt` repositories;
 - LANDIS-II placed at `/opt/landis-ii`;
 - extension and library versions defined in shared `*.yaml` files;
@@ -94,9 +97,17 @@ Build from the repository root so that shared files (`extension_files/`, `script
 ```shell
 cd ~/Tool-Docker-Apptainer
 
+## Ubuntu 26.04 (resolute) — recommended
 docker build . \
   -f Docker-LANDIS-II-v8-UCL2-release/Dockerfile \
-  -t landis-ii-v8-uclv2-release:release
+  --build-arg UBUNTU_VERSION=26.04 \
+  -t landis-ii-v8-uclv2-release:ubuntu-26.04
+
+## Ubuntu 24.04 (noble)
+docker build . \
+  -f Docker-LANDIS-II-v8-UCL2-release/Dockerfile \
+  --build-arg UBUNTU_VERSION=24.04 \
+  -t landis-ii-v8-uclv2-release:ubuntu-24.04
 ```
 
 ### Windows (PowerShell)
@@ -104,14 +115,22 @@ docker build . \
 ```shell
 cd ~/Tool-Docker-Apptainer
 
+## Ubuntu 26.04 (resolute) — recommended
 docker build . `
   -f Docker-LANDIS-II-v8-UCL2-release/Dockerfile `
-  -t landis-ii-v8-uclv2-release:release
+  --build-arg UBUNTU_VERSION=26.04 `
+  -t landis-ii-v8-uclv2-release:ubuntu-26.04
+
+## Ubuntu 24.04 (noble)
+docker build . `
+  -f Docker-LANDIS-II-v8-UCL2-release/Dockerfile `
+  --build-arg UBUNTU_VERSION=24.04 `
+  -t landis-ii-v8-uclv2-release:ubuntu-24.04
 ```
 
 ## Run a locally built container
 
-Replace `landis-ii-v8-uclv2-release:release` with `ghcr.io/landis-ii-foundation/landis-ii-v8-uclv2-release:main` if you pulled the pre-built image instead.
+Replace `landis-ii-v8-uclv2-release:ubuntu-26.04` with `ghcr.io/landis-ii-foundation/landis-ii-v8-uclv2-release:ubuntu-latest` if you pulled the pre-built image instead.
 
 ### Interactive container
 
@@ -123,7 +142,7 @@ docker run -it \
   --memory=64g \
   --mount type=bind,src="/path/to/your/scenario",dst=/scenarioFolder \
   --name landis01 \
-  landis-ii-v8-uclv2-release:release
+  landis-ii-v8-uclv2-release:ubuntu-26.04
 ```
 
 #### Windows (PowerShell)
@@ -134,7 +153,7 @@ docker run -it `
   --memory=64g `
   --mount type=bind,src="C:\path\to\your\scenario",dst=/scenarioFolder `
   --name landis01 `
-  landis-ii-v8-uclv2-release:release
+  landis-ii-v8-uclv2-release:ubuntu-26.04
 ```
 
 ### Non-interactive container (run a single simulation)
@@ -147,7 +166,7 @@ docker run --rm \
   --memory=64g \
   --mount type=bind,src="/path/to/your/scenario",dst=/scenarioFolder \
   --name landis01 \
-  landis-ii-v8-uclv2-release:release \
+  landis-ii-v8-uclv2-release:ubuntu-26.04 \
   /bin/sh -c "cd /scenarioFolder && dotnet \$LANDIS_CONSOLE scenario.txt"
 ```
 
@@ -159,6 +178,6 @@ docker run --rm `
   --memory=64g `
   --mount type=bind,src="C:\path\to\your\scenario",dst=/scenarioFolder `
   --name landis01 `
-  landis-ii-v8-uclv2-release:release `
+  landis-ii-v8-uclv2-release:ubuntu-26.04 `
   /bin/sh -c "cd /scenarioFolder && dotnet `$LANDIS_CONSOLE scenario.txt"
 ```

--- a/Docker-LANDIS-II-v8-release/Dockerfile
+++ b/Docker-LANDIS-II-v8-release/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:24.04
+ARG UBUNTU_VERSION=24.04
+FROM ubuntu:${UBUNTU_VERSION}
+ARG UBUNTU_VERSION   ## must re-declare after FROM to stay in scope
 
 LABEL org.opencontainers.image.authors="clem.hardy@pm.me; achubaty@for-cast.ca;"
 
@@ -16,6 +18,10 @@ ENV LC_ALL=C.UTF-8
 ## - python needed for Magic Harvest;
 ## - `xmlstarlet` used to edit xml in .csproj files;
 RUN apt-get update && apt-get upgrade -y \
+  && apt-get install -y software-properties-common \
+  && if [ "${UBUNTU_VERSION}" = "26.04" ]; then \
+       add-apt-repository ppa:dotnet/backports && apt-get update; \
+     fi \
   && apt-get install -y \
     dotnet-sdk-8.0 \
     gdal-bin \
@@ -25,14 +31,22 @@ RUN apt-get update && apt-get upgrade -y \
     libpng16-16t64 \
     mono-utils \
     nano \
-    pip \
     python3 \
+    python3-pip \
     python-is-python3 \
-    software-properties-common \
     vim \
     wget \
     xmlstarlet \
   && apt-get clean -y && rm -rf /var/lib/apt/lists/* ## clean up to save space
+
+## Ubuntu 26.04 changed SO names for three libraries that Gdal.Core NuGet's bundled libgdal.so.20
+## was compiled against: libxml2 (.so.2 → .so.16), libicuuc/libicudata (.so.74 → .so.78)
+RUN if [ "${UBUNTU_VERSION}" = "26.04" ]; then \
+      ln -s /usr/lib/x86_64-linux-gnu/libxml2.so.16 /usr/lib/x86_64-linux-gnu/libxml2.so.2 \
+      && ln -s /usr/lib/x86_64-linux-gnu/libicuuc.so.78 /usr/lib/x86_64-linux-gnu/libicuuc.so.74 \
+      && ln -s /usr/lib/x86_64-linux-gnu/libicudata.so.78 /usr/lib/x86_64-linux-gnu/libicudata.so.74 \
+      && ldconfig; \
+    fi
 
 ## install yq (used to parse yaml files) from source
 RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq \

--- a/Docker-LANDIS-II-v8-release/README.md
+++ b/Docker-LANDIS-II-v8-release/README.md
@@ -1,6 +1,6 @@
 # Docker-LANDIS-II-v8-release
 
-LANDIS-II v8 (Ubuntu 24.04) with a fixed, tested set of extensions defined in [`extensions-v8-release.yaml`](../extensions-v8-release.yaml).
+LANDIS-II v8 (Ubuntu 24.04 and 26.04) with a fixed, tested set of extensions defined in [`extensions-v8-release.yaml`](../extensions-v8-release.yaml).
 
 **For users:** pull the pre-built image (no build step required).
 **For developers:** build the image locally using the instructions below.
@@ -8,8 +8,11 @@ LANDIS-II v8 (Ubuntu 24.04) with a fixed, tested set of extensions defined in [`
 ## Quick start: use the pre-built image
 
 ```shell
-docker pull ghcr.io/landis-ii-foundation/landis-ii-v8-release:main
+docker pull ghcr.io/landis-ii-foundation/landis-ii-v8-release:ubuntu-latest
 ```
+
+> 💡 **Tags:** `:ubuntu-latest`, `:latest`, and `:main` all point to the most recent Ubuntu LTS build (currently Ubuntu 26.04).
+> Use `:ubuntu-24.04` or `:ubuntu-26.04` to pin to a specific OS version.
 
 Then run a simulation (replace the path with your scenario folder):
 
@@ -19,7 +22,7 @@ docker run --rm \
   --cpus=4 \
   --memory=64g \
   --mount type=bind,src="/path/to/your/scenario",dst=/scenarioFolder \
-  ghcr.io/landis-ii-foundation/landis-ii-v8-release:main \
+  ghcr.io/landis-ii-foundation/landis-ii-v8-release:ubuntu-latest \
   /bin/sh -c "cd /scenarioFolder && dotnet \$LANDIS_CONSOLE scenario.txt"
 
 ## Windows (PowerShell)
@@ -27,7 +30,7 @@ docker run --rm `
   --cpus=4 `
   --memory=64g `
   --mount type=bind,src="C:\path\to\your\scenario",dst=/scenarioFolder `
-  ghcr.io/landis-ii-foundation/landis-ii-v8-release:main `
+  ghcr.io/landis-ii-foundation/landis-ii-v8-release:ubuntu-latest `
   /bin/sh -c "cd /scenarioFolder && dotnet `$LANDIS_CONSOLE scenario.txt"
 ```
 
@@ -79,7 +82,7 @@ See [`extensions-v8-release.yaml`](../extensions-v8-release.yaml) and [`librarie
 
 This image supersedes `Clean_Docker_LANDIS-II_8_AllExtensions` with the following improvements:
 
-- Ubuntu 24.04 (noble) base image instead of 22.04 (jammy);
+- Ubuntu 24.04 (noble) and 26.04 (resolute) base images, selectable via `--build-arg UBUNTU_VERSION=<version>`; defaults to 24.04;
 - `dotnet` installed from the `apt` repositories;
 - LANDIS-II placed at `/opt/landis-ii` (standard location for third-party software);
 - extension and library versions defined in shared `*.yaml` files, not hardcoded in the Dockerfile;
@@ -97,9 +100,17 @@ Build from the repository root so that shared files (`extension_files/`, `script
 ```shell
 cd ~/Tool-Docker-Apptainer
 
+## Ubuntu 26.04 (resolute) — recommended
 docker build . \
   -f Docker-LANDIS-II-v8-release/Dockerfile \
-  -t landis-ii-v8-release:release
+  --build-arg UBUNTU_VERSION=26.04 \
+  -t landis-ii-v8-release:ubuntu-26.04
+
+## Ubuntu 24.04 (noble)
+docker build . \
+  -f Docker-LANDIS-II-v8-release/Dockerfile \
+  --build-arg UBUNTU_VERSION=24.04 \
+  -t landis-ii-v8-release:ubuntu-24.04
 ```
 
 ### Windows (PowerShell)
@@ -107,14 +118,22 @@ docker build . \
 ```shell
 cd ~/Tool-Docker-Apptainer
 
+## Ubuntu 26.04 (resolute) — recommended
 docker build . `
   -f Docker-LANDIS-II-v8-release/Dockerfile `
-  -t landis-ii-v8-release:release
+  --build-arg UBUNTU_VERSION=26.04 `
+  -t landis-ii-v8-release:ubuntu-26.04
+
+## Ubuntu 24.04 (noble)
+docker build . `
+  -f Docker-LANDIS-II-v8-release/Dockerfile `
+  --build-arg UBUNTU_VERSION=24.04 `
+  -t landis-ii-v8-release:ubuntu-24.04
 ```
 
 ## Run a locally built container
 
-Replace `landis-ii-v8-release:release` with `ghcr.io/landis-ii-foundation/landis-ii-v8-release:main` if you pulled the pre-built image instead.
+Replace `landis-ii-v8-release:ubuntu-26.04` with `ghcr.io/landis-ii-foundation/landis-ii-v8-release:ubuntu-latest` if you pulled the pre-built image instead.
 
 ### Interactive container
 
@@ -126,7 +145,7 @@ docker run -it \
   --memory=64g \
   --mount type=bind,src="/path/to/your/scenario",dst=/scenarioFolder \
   --name landis01 \
-  landis-ii-v8-release:release
+  landis-ii-v8-release:ubuntu-26.04
 ```
 
 #### Windows (PowerShell)
@@ -137,7 +156,7 @@ docker run -it `
   --memory=64g `
   --mount type=bind,src="C:\path\to\your\scenario",dst=/scenarioFolder `
   --name landis01 `
-  landis-ii-v8-release:release
+  landis-ii-v8-release:ubuntu-26.04
 ```
 
 ### Non-interactive container (run a single simulation)
@@ -150,7 +169,7 @@ docker run --rm \
   --memory=64g \
   --mount type=bind,src="/path/to/your/scenario",dst=/scenarioFolder \
   --name landis01 \
-  landis-ii-v8-release:release \
+  landis-ii-v8-release:ubuntu-26.04 \
   /bin/sh -c "cd /scenarioFolder && dotnet \$LANDIS_CONSOLE scenario.txt"
 ```
 
@@ -162,6 +181,6 @@ docker run --rm `
   --memory=64g `
   --mount type=bind,src="C:\path\to\your\scenario",dst=/scenarioFolder `
   --name landis01 `
-  landis-ii-v8-release:release `
+  landis-ii-v8-release:ubuntu-26.04 `
   /bin/sh -c "cd /scenarioFolder && dotnet `$LANDIS_CONSOLE scenario.txt"
 ```

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ These images provide a minimal LANDIS-II installation, including GDAL, plus a Py
 
 | Image name             | Subdirectory                               | Description                                         |
 | ---------------------- | ------------------------------------------ | --------------------------------------------------- |
-| `landis-ii-v8-release` | `Docker-LANDIS-II-v8-release/`             | LANDIS-II v8 (Ubuntu 24.04); [fixed versions of v8 extensions](extensions-v8-release.yaml) |
-| `landis-ii-v8-uclv2-release` | `Docker-LANDIS-II-v8-UCL2-release/` | LANDIS-II v8 (Ubuntu 24.04); [extensions updated for UCL v2](extensions-v8-UCL2-release.yaml) |
+| `landis-ii-v8-release` | `Docker-LANDIS-II-v8-release/`             | LANDIS-II v8 (Ubuntu 24.04 and 26.04); [fixed versions of v8 extensions](extensions-v8-release.yaml) |
+| `landis-ii-v8-uclv2-release` | `Docker-LANDIS-II-v8-UCL2-release/` | LANDIS-II v8 (Ubuntu 24.04 and 26.04); [extensions updated for UCL v2](extensions-v8-UCL2-release.yaml) |
 | ~~`landis-ii-v8-linux`~~ | ~~`Clean_Docker_LANDIS-II_8_AllExtensions/`~~ | **Deprecated** — superseded by `landis-ii-v8-release` |
 
 ### R/RStudio images
@@ -101,8 +101,8 @@ These images are based on the generic images and add R and/or a running RStudio 
 
 | Image name             | Subdirectory                               | Description                                         |
 | ---------------------- | ------------------------------------------ | --------------------------------------------------- |
-| `landis-ii-v8-r`       | `Docker-LANDIS-II-v8-R/`                   | LANDIS-II v8 (Ubuntu 24.04); [fixed versions of v8 extensions](extensions-v8-release.yaml); R 4.6.0 |
-| `landis-ii-v8-rstudio` | `Docker-LANDIS-II-v8-Rstudio/`             | LANDIS-II v8 (Ubuntu 24.04); [fixed versions of v8 extensions](extensions-v8-release.yaml); R 4.6.0; RStudio Server |
+| `landis-ii-v8-r`       | `Docker-LANDIS-II-v8-R/`                   | LANDIS-II v8 (Ubuntu 24.04 via `rocker/r-ver:4.6.0`); [fixed versions of v8 extensions](extensions-v8-release.yaml); R 4.6.0 |
+| `landis-ii-v8-rstudio` | `Docker-LANDIS-II-v8-Rstudio/`             | LANDIS-II v8 (Ubuntu 24.04 via `rocker/geospatial:4.6.0`); [fixed versions of v8 extensions](extensions-v8-release.yaml); R 4.6.0; RStudio Server |
 
 ### Other custom images
 
@@ -118,8 +118,15 @@ Pre-built images are publicly available on the GitHub Container Registry and **d
 
 ```shell
 ## replace <imagename> with one from the tables above (e.g., landis-ii-v8-release)
-docker pull ghcr.io/landis-ii-foundation/<imagename>:main
+docker pull ghcr.io/landis-ii-foundation/<imagename>:ubuntu-latest
 ```
+
+> 💡 **Image tags:** All images provide the following tags:
+> - `:ubuntu-latest` — most recent Ubuntu LTS build **(recommended)**
+> - `:latest` — alias for `:ubuntu-latest`
+> - `:main` — alias for `:ubuntu-latest`, kept for backwards compatibility
+> - `:ubuntu-<version>` — pinned to a specific Ubuntu version (e.g. `:ubuntu-24.04`, `:ubuntu-26.04`);
+>   useful for reproducibility or if a newer OS version introduces unexpected behaviour
 
 > 💡 You can also skip the `docker pull` step entirely: if you use an image name in a `docker run` command and the image is not already on your computer, Docker will download it automatically.
 


### PR DESCRIPTION
Closes #45

Adds Ubuntu 26.04 (resolute) as a supported build target for `landis-ii-v8-release`
and `landis-ii-v8-uclv2-release`. LANDIS-II v7 stays on Ubuntu 22.04 (v7 requires
.NET 2.2 which is incompatible with Ubuntu 24/26); the R/RStudio images remain on
their rocker base images (currently Ubuntu 24.04) and will be updated when
rocker releases Ubuntu 26.04 base images.

## What changed

**Dockerfiles** (`Docker-LANDIS-II-v8-release`, `Docker-LANDIS-II-v8-UCL2-release`):
- Parameterised base image via `ARG UBUNTU_VERSION=24.04` / `FROM ubuntu:${UBUNTU_VERSION}`
- On Ubuntu 26.04: adds `ppa:dotnet/backports` so `dotnet-sdk-8.0` is available
- On Ubuntu 26.04: adds compatibility symlinks for SO-version renames that affect
  the bundled `libgdal.so.20` shipped in the `Gdal.Core` NuGet package:
  `libxml2.so.2 → .so.16`, `libicuuc.so.74 → .so.78`, `libicudata.so.74 → .so.78`

**CI (`.github/workflows/docker-publish.yml`)**:
- Matrix now builds each v8 image twice (24.04 and 26.04)
- Tag scheme per image:
  | Tag | Meaning |
  |-----|---------|
  | `:ubuntu-26.04` | Ubuntu 26.04 build |
  | `:ubuntu-24.04` | Ubuntu 24.04 build |
  | `:ubuntu-latest` / `:latest` | Points to Ubuntu 26.04 (most recent) |
  | `:main` | Same as `:ubuntu-latest` — retained for backwards compatibility |

**READMEs**: updated pull/run examples to use `:ubuntu-latest`; added tag reference
notes; updated build instructions with `--build-arg UBUNTU_VERSION=` examples.

## Tests

Both Ubuntu versions were built and tested locally against the included test scenarios:

- [x] `landis-ii-v8-release` Ubuntu 24.04 — TestPnET_AllExtension ✓  TestForCS_v8 ✓
- [x] `landis-ii-v8-release` Ubuntu 26.04 — TestPnET_AllExtension ✓  TestForCS_v8 ✓

@Klemet can you please review?