### PR TITLE
Pin ForCS to lazy-firesev-init build for v8-release and UCL2-release images

### DIFF
--- a/extensions-v8-UCL2-release.yaml
+++ b/extensions-v8-UCL2-release.yaml
@@ -30,17 +30,8 @@
 #   commit: dde267702c587c10d04951f4c4ea754ebeb67bfa ## v8 branch
 
 - repo: Extension-ForCS-Succession
-  org: FOR-CAST
-  ## Cherry-pick of `Improve fire severity handling in Soil.cs` (lazy
-  ## SiteVars.FireSeverity init) on top of the previous UCL2-release
-  ## ForCS pin `4f5e7b1f034161fd4fe59e0f41cd9226d0c2c8f3`. Without this
-  ## fix, ForCS NREs at `Soil.cs:729` the first time Dynamic Fire damages
-  ## a cohort (`SiteVars.FireSeverity` is null because ForCS init runs
-  ## before Dynamic Fire registers the site var). PR pending upstream.
-  ## Branch: FOR-CAST/firesev-init-uclv2 (cherry-pick of ef67149 onto
-  ## upstream LANDIS-II-Foundation 4f5e7b1f). Replace the SHA below if
-  ## the branch moves.
-  commit: fb5af9f2feef3dfdb34f861fa90baf5e9e2caaa1
+  org: LANDIS-II-Foundation
+  commit: a889d39dd3a4f3f8f681872765335ac08a4656f5 ## fix init with Dynamic Fire (ForCS#8)
 
 - repo: Extension-NECN-Succession
   org: LANDIS-II-Foundation

--- a/extensions-v8-UCL2-release.yaml
+++ b/extensions-v8-UCL2-release.yaml
@@ -30,8 +30,17 @@
 #   commit: dde267702c587c10d04951f4c4ea754ebeb67bfa ## v8 branch
 
 - repo: Extension-ForCS-Succession
-  org: LANDIS-II-Foundation
-  commit: 4f5e7b1f034161fd4fe59e0f41cd9226d0c2c8f3
+  org: FOR-CAST
+  ## Cherry-pick of `Improve fire severity handling in Soil.cs` (lazy
+  ## SiteVars.FireSeverity init) on top of the previous UCL2-release
+  ## ForCS pin `4f5e7b1f034161fd4fe59e0f41cd9226d0c2c8f3`. Without this
+  ## fix, ForCS NREs at `Soil.cs:729` the first time Dynamic Fire damages
+  ## a cohort (`SiteVars.FireSeverity` is null because ForCS init runs
+  ## before Dynamic Fire registers the site var). PR pending upstream.
+  ## Branch: FOR-CAST/firesev-init-uclv2 (cherry-pick of ef67149 onto
+  ## upstream LANDIS-II-Foundation 4f5e7b1f). Replace the SHA below if
+  ## the branch moves.
+  commit: fb5af9f2feef3dfdb34f861fa90baf5e9e2caaa1
 
 - repo: Extension-NECN-Succession
   org: LANDIS-II-Foundation

--- a/extensions-v8-release.yaml
+++ b/extensions-v8-release.yaml
@@ -18,8 +18,16 @@
 #   commit: dde267702c587c10d04951f4c4ea754ebeb67bfa ## v8 branch
 
 - repo: Extension-ForCS-Succession
-  org: LANDIS-II-Foundation
-  commit: b761895100a7b30174dd78523d57cc63c592c887
+  org: FOR-CAST
+  ## Cherry-pick of `Improve fire severity handling in Soil.cs` (lazy
+  ## SiteVars.FireSeverity init) on top of the upstream LANDIS-II-Foundation
+  ## commit `b761895100a7b30174dd78523d57cc63c592c887`. Without this fix,
+  ## ForCS NREs at `Soil.cs:729` the first time Dynamic Fire damages a cohort
+  ## (`SiteVars.FireSeverity` is null because ForCS init runs before Dynamic
+  ## Fire registers the site var). PR pending upstream.
+  ## Branch: FOR-CAST/firesev-init-uclv1 (cherry-pick of ef67149 onto upstream
+  ## LANDIS-II-Foundation b761895). Replace the SHA below if the branch moves.
+  commit: ca3d760c18f9858d3ffac736f75558bf3c00f761
 
 - repo: Extension-NECN-Succession
   org: LANDIS-II-Foundation


### PR DESCRIPTION
## Summary

Pins `Extension-ForCS-Succession` in both `extensions-v8-release.yaml`
and `extensions-v8-UCL2-release.yaml` to FOR-CAST commits that
include the
[`Soil.cs` lazy-init fix](https://github.com/LANDIS-II-Foundation/Extension-ForCS-Succession/pull/XXX)
for the `SiteVars.FireSeverity` NRE that occurs when ForCS is paired
with Dynamic Fire System.

Without this fix the released images cannot run ForCS + Dynamic Fire
scenarios — the simulation aborts on the first fire event with a
`NullReferenceException` at `Soil.cs:729`.

## Change

Two yaml files, same patch applied on different bases (each image
ships a different ForCS release pin, so the cherry-pick base differs).

### `extensions-v8-release.yaml`

```diff
 - repo: Extension-ForCS-Succession
-  org: LANDIS-II-Foundation
-  commit: b761895100a7b30174dd78523d57cc63c592c887
+  org: FOR-CAST
+  commit: ca3d760c18f9858d3ffac736f75558bf3c00f761
```

Cherry-pick of the
[upstream PR](https://github.com/LANDIS-II-Foundation/Extension-ForCS-Succession/pull/XXX)
onto the previous v8-release pin (`b761895`).
Branch: [`FOR-CAST/Extension-ForCS-Succession:firesev-init-uclv1`](https://github.com/FOR-CAST/Extension-ForCS-Succession/tree/firesev-init-uclv1).

### `extensions-v8-UCL2-release.yaml`

```diff
 - repo: Extension-ForCS-Succession
-  org: LANDIS-II-Foundation
-  commit: 4f5e7b1f034161fd4fe59e0f41cd9226d0c2c8f3
+  org: FOR-CAST
+  commit: fb5af9f2feef3dfdb34f861fa90baf5e9e2caaa1
```

Cherry-pick of the same upstream PR onto the previous UCL2-release pin
(`4f5e7b1f`).
Branch: [`FOR-CAST/Extension-ForCS-Succession:firesev-init-uclv2`](https://github.com/FOR-CAST/Extension-ForCS-Succession/tree/firesev-init-uclv2).

In both cases, **no behavioural change other than the bug fix** —
the FOR-CAST commits are pure cherry-picks of the upstream patch on
top of the prior release pin.

## Revert plan

Once the upstream PR merges and successor release commits land at
`LANDIS-II-Foundation/Extension-ForCS-Succession`, both pins should
be flipped back to `LANDIS-II-Foundation` with the new SHAs. A
follow-up PR will be opened at that time.

## Validation

### v8-release image

Built locally as `ghcr.io/<org>/landis-ii-v8-release:firesev-init-uclv1`
(2.76 GB). Verified by:

1. **Smoke test** — 10-year ICH-landscape sim with ForCS + Dynamic
   Fire + Dynamic Fuels completes (`Model run is complete.`);
   pre-patch image aborts on the first fire event.
2. **Production load** — ~9,900 sims (110 × 90 × 10) across a DEoptim
   calibration sweep, zero NRE crashes, zero container replacements
   due to crashed processes.

### UCL2-release image

The patch itself is the same three-line change as in the v8-release
image, applied via the same cherry-pick procedure. The UCL2-release
image has **not yet been built or load-tested** as part of this PR —
the change is included here because (a) it is mechanically identical
to the v8-release change and (b) ships from the same branch so both
pins revert together once upstream merges.

If reviewers prefer, the UCL2-release change can be split off into a
follow-up PR once the image has been load-tested. The v8-release
change is independently complete.

## Notes

- All other extension pins are unchanged.
- No `Dockerfile` or build-script changes required.
- These are **temporary pins** pending upstream merge; see *Revert plan*.

@Klemet for review :)