### PR TITLE
Automate Apptainer (.sif) builds and publish to Releases

### DIFF
--- a/.github/workflows/apptainer-publish.yml
+++ b/.github/workflows/apptainer-publish.yml
@@ -1,0 +1,88 @@
+name: Build and publish Apptainer (.sif) images
+
+## Builds Apptainer/Singularity .sif images directly from the Docker images
+## already published to the GitHub Container Registry (ghcr.io) by
+## `docker-publish.yml`, then attaches them to a GitHub Release.
+##
+## Why this design:
+##   - We convert straight from `docker://ghcr.io/...`, so there is no
+##     `docker save` / tarball step and no local Docker daemon needed.
+##   - Only the simulation images are converted (see matrix below). The R /
+##     RStudio images are larger and not a typical HPC batch use case, so they
+##     are intentionally excluded; if ever needed, publish those as an OCI/ORAS
+##     artifact (`apptainer push ... oras://ghcr.io/...`) to avoid the 2 GB
+##     GitHub Release asset limit.
+##
+## Triggers:
+##   - `release: published` — the normal path. Cut a GitHub Release and the
+##     matching `.sif` files are built from the current `:ubuntu-latest` images
+##     and uploaded as release assets.
+##   - `workflow_dispatch` — manual run for testing or one-off builds; results
+##     are uploaded as workflow artifacts (no release to attach to). An optional
+##     `tag` input lets you target a specific image tag (e.g. `ubuntu-26.04`).
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Docker image tag to convert (e.g. ubuntu-latest, ubuntu-24.04, ubuntu-26.04)"
+        default: "ubuntu-latest"
+        required: false
+
+permissions:
+  contents: write   # upload release assets
+  packages: read    # pull source images from ghcr
+
+jobs:
+  build-sif:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ## Simulation images only — each is well under the 2 GB release-asset
+        ## limit (v8-release / v8-uclv2-release are multi-stage "slim" builds;
+        ## v7-release is ~1.5 GB as a .sif).
+        image:
+          - landis-ii-v7-release
+          - landis-ii-v8-release
+          - landis-ii-v8-uclv2-release
+        ## To also publish the R image, add `landis-ii-v8-r` here AND switch its
+        ## upload to an ORAS push (it can exceed 2 GB). RStudio is omitted on
+        ## purpose (interactive server, not an HPC batch workload).
+
+    steps:
+      - name: Set up Apptainer
+        uses: apptainer/setup-apptainer@v2
+
+      - name: Build .sif from the published Docker image
+        env:
+          ## Authenticate the docker:// pull to avoid anonymous ghcr rate limits
+          ## (also required if the source image is ever made private).
+          APPTAINER_DOCKER_USERNAME: ${{ github.actor }}
+          APPTAINER_DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          owner=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          tag="${{ github.event.inputs.tag || 'ubuntu-latest' }}"
+          src="docker://ghcr.io/${owner}/${{ matrix.image }}:${tag}"
+          out="${{ matrix.image }}.sif"
+          echo "Building ${out} from ${src}"
+          apptainer build "${out}" "${src}"
+          ls -lh "${out}"
+          echo "SIF=${out}" >> "$GITHUB_ENV"
+
+      - name: Attach .sif to the release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.event.release.tag_name }}" "${SIF}" --clobber
+
+      - name: Upload .sif as a workflow artifact
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.image }}-sif
+          path: ${{ env.SIF }}
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -363,28 +363,48 @@ docker run \
 
 Simply make sure that the command `cd /scenarioFolder` goes where your `scenario.txt` file is located. If it's in a subfolder, change it to `cd /scenarioFolder/subFolder`.
 
-### 📦 (Optional) Building an apptainer file to use LANDIS-II on HPC environments (e.g. supercomputing clusters)
+### 📦 Using LANDIS-II on HPC environments (e.g. supercomputing clusters) with Apptainer
 
-You can easily create an Apptainer file (in `.sif` format) from a Docker image to deploy on HPC environments.
+On HPC clusters, Docker is usually forbidden and you use [Apptainer](https://apptainer.org/)
+(formerly Singularity) instead. Apptainer runs a single `.sif` file, which you can either
+**download pre-built** or **build yourself** from any of our Docker images.
 
-- First, you need to install Apptainer (the program) on your computer. This can only be done in Linux.
-  If you are on Windows, you can use the WSL that we installed with Docker Desktop (see above)
-  to run an Ubuntu console on your Windows computer. Simply run `wsl -d Ubuntu` in a Powershell terminal.
-  You can also create a Docker container that contains Apptainer.
-  See [this repository](https://github.com/kaczmarj/apptainer-in-docker) for one.
-- Next, you need to export your Docker image as an archive file.
-  Use `docker save <NAME OF DOCKER IMAGE> -o <DOCKER ARCHIVE FILE NAME>.tar` in the terminal.
-- Then, you need to use a Linux terminal with Apptainer installed, and change your working directory
-  to go the folder containing your `.tar` docker archive file.
-- Finally, use this command to build the Apptainer image:
-  
+#### Option 1 (recommended): download a pre-built `.sif`
+
+Pre-built `.sif` files for the simulation images are attached to our
+[Releases](https://github.com/LANDIS-II-Foundation/Tool-Docker-Apptainer/releases).
+Download the one you need — e.g. directly on the cluster with `wget`/`curl` — and follow the
+run instructions below. No build step required.
+
+These `.sif` files are built automatically from the published Docker images, so they stay in
+sync with each release.
+
+#### Option 2: build a `.sif` yourself
+
+Because the Docker images are published to the GitHub Container Registry, Apptainer can build a
+`.sif` **directly from the registry** — there is no need to `docker save` to a `.tar` first:
+
+```shell
+## replace <imagename> with one from the tables above (e.g. landis-ii-v8-release)
+apptainer build <imagename>.sif docker://ghcr.io/landis-ii-foundation/<imagename>:ubuntu-latest
+```
+
+Apptainer only runs on Linux, so:
+
+- **On Linux** — including the WSL Ubuntu that ships with Docker Desktop (run `wsl -d Ubuntu` in
+  a PowerShell terminal) — [install Apptainer](https://apptainer.org/docs/admin/main/installation.html)
+  and run the command above.
+- **On Windows without WSL** — run the build inside a container that already includes Apptainer,
+  so you don't have to install anything extra:
+
   ```shell
-  apptainer build --fakeroot <NAME OF YOUR APPTAINER FILE>.sif docker-archive://<DOCKER ARCHIVE FILE NAME>.tar
+  docker run --rm --privileged kaczmarj/apptainer:latest \
+    build /work/<imagename>.sif docker://ghcr.io/landis-ii-foundation/<imagename>:ubuntu-latest
   ```
 
-  > ⚠ This compilation often takes a lot of RAM, and will fail if you do not have enough of it available!
-  > If that's the case, you can download and use one of the `.sif` files available from the
-  > [Releases](https://github.com/LANDIS-II-Foundation/Tool-Docker-Apptainer/releases) section of this repository.
+> 💡 The slim v8 images build into small `.sif` files (a few hundred MB) on a normal laptop.
+> If a build runs out of RAM — or you simply want to avoid building — use the pre-built `.sif`
+> from the [Releases](https://github.com/LANDIS-II-Foundation/Tool-Docker-Apptainer/releases) (Option 1).
 
 To use the Apptainer on a HPC environment :
 


### PR DESCRIPTION
Builds Apptainer `.sif` images automatically and publishes them, addressing #18 and #40.

> [!IMPORTANT]
> **Depends on #61.** This builds `.sif` files from the published Docker images and relies on #61's slim multi-stage v8 images to keep `v8-release`/`v8-uclv2-release` well under the 2 GB release-asset limit. Please merge #61 first.

### What it does

- New workflow `.github/workflows/apptainer-publish.yml`, triggered on `release: published` (plus `workflow_dispatch` for manual/test runs).
- Builds each `.sif` straight from `ghcr.io` (`apptainer build … docker://…`) — no `docker save`/tar, no local daemon — and attaches it to the release.
- Scope: the three simulation images (`v7-release`, `v8-release`, `v8-uclv2-release`). R/RStudio are omitted (larger; not a typical HPC batch workload).
- README: lead with downloading a pre-built `.sif`; simplify the self-build to a one-line registry build; keep a Windows-without-WSL fallback via `kaczmarj/apptainer`; soften the RAM warning now that the slim images are small.

### Testing

Not yet run against a release. Can be dry-run now via **Run workflow** (`workflow_dispatch`), which builds the SIFs and uploads them as workflow artifacts without needing a release.

cc @Klemet for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
