### PR TITLE
use upstream pins for Dynamic Fire and Dynamic Biomass Fuels

### DIFF
--- a/extensions-v8-UCL2-release.yaml
+++ b/extensions-v8-UCL2-release.yaml
@@ -60,12 +60,12 @@
   commit: bef44491f37ffd6950d26bf9d1425db509e974fe
 
 - repo: Extension-Dynamic-Biomass-Fuels
-  org: FOR-CAST
-  commit: 2ab687b4ad9a7e88fed081b6e8d396db8fe5ed0a ## FOR-CAST fork: UCLv2 + missing-HintPath build fix (pending upstream PR)
+  org: LANDIS-II-Foundation
+  commit: 4e3e2f1225b3c72ddaff345932ce3e3b96bd039d
 
 - repo: Extension-Dynamic-Fire-System
-  org: FOR-CAST
-  commit: e0fc140df03a3f6398b2b3415df04a4343753288 ## FOR-CAST fork: UCLv2 + missing-HintPath build fix (pending upstream PR)
+  org: LANDIS-II-Foundation
+  commit: 63d38a7a2b7b5da73eaf7ca448edc44afd774cc4
 
 ## Extension-Land-Use-Plus: excluded -- upstream UCLv2 migration is unfinished.
 ## master HEAD (cea58ef, the latest commit, itself a mid-migration "still won't


### PR DESCRIPTION
Follows up on #58 following merge of PRs to upstream:

- https://github.com/LANDIS-II-Foundation/Extension-Dynamic-Fire-System/pull/13
- https://github.com/LANDIS-II-Foundation/Extension-Dynamic-Biomass-Fuels/pull/12

@Klemet ready for your review