### PR TITLE
Fix Apptainer setup action reference (apptainer→eWaterCycle)

### DIFF
--- a/.github/workflows/apptainer-publish.yml
+++ b/.github/workflows/apptainer-publish.yml
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Set up Apptainer
-        uses: apptainer/setup-apptainer@v2
+        uses: eWaterCycle/setup-apptainer@v2
 
       - name: Build .sif from the published Docker image
         env:


### PR DESCRIPTION
Follow-up to #62. The `apptainer-publish.yml` workflow references a non-existent action `apptainer/setup-apptainer` (HTTP 404), so every job failed immediately. The correct action is `eWaterCycle/setup-apptainer`.

### Verification

Dispatched the fixed workflow on the FOR-CAST fork — all three jobs succeeded and produced `.sif` artifacts, all comfortably under the 2 GB release-asset limit:

| Image | `.sif` size |
| ----- | ----------- |
| `landis-ii-v7-release` | 957 MB |
| `landis-ii-v8-release` | 172 MB |
| `landis-ii-v8-uclv2-release` | 172 MB |

Run: https://github.com/FOR-CAST/Tool-Docker-Apptainer/actions/runs/28243176463 (build + artifact-upload path). The release-asset upload step (`gh release upload`) only runs on a real `release: published` event and was correctly skipped on this manual run.

cc @Klemet
