### PR TITLE
Pin Social Climate Fire to upstream v4.3; document its succession limits

### DIFF
--- a/Docker-LANDIS-II-v8-UCL2-release/README.md
+++ b/Docker-LANDIS-II-v8-UCL2-release/README.md
@@ -61,9 +61,22 @@ See [`extensions-v8-UCL2-release.yaml`](../extensions-v8-UCL2-release.yaml),
 | Biomass Hurricane |
 | Dynamic Biomass Fuels |
 | Dynamic Fire System |
-| Social Climate Fire |
+| Social Climate Fire (SCRAPPLE) [^scrapple] |
 | Forest Roads Simulation |
 | Magic Harvest |
+
+[^scrapple]: **Only usable with NECN and PnET succession.** Under ForCS Succession or
+    Biomass Succession it crashes at extension load with a `NullReferenceException` in
+    `SiteVars.InitializeDisturbances()`. SCRAPPLE reads fine fuels from
+    `Succession.FineFuels`; when that site variable is unregistered it falls back to
+    `Succession.Litter`, but assigns the result into `SiteVars.FineFuels[site]` — whose
+    getter returns the same field it just found null — so the fallback dereferences null.
+    NECN registers `Succession.FineFuels` directly and PnET registers it via
+    `Library-PnET-Cohort`, so both take the working branch; ForCS and Biomass Succession
+    register only `Succession.Litter`. This is an upstream SCRAPPLE bug, **not** a UCLv2
+    issue: it reproduces on the UCLv1 pin used by `landis-ii-v8-release`, and is still
+    present on upstream master as of v4.3. Fixing it upstream is a one-liner — allocate
+    the site variable (`NewSiteVar<double>()`) before populating it from the litter pool.
 
 **Output**
 

--- a/extensions-v8-UCL2-release.yaml
+++ b/extensions-v8-UCL2-release.yaml
@@ -85,10 +85,32 @@
 #   org: LANDIS-II-Foundation
 #   commit: fde29473f773c9f995f3a702ca919f7f30a6bcd1
 
-## TODO: use LANDIS-II-Foundation
+## Upstream absorbed the UCLv2 migration (`Update UCL and Rebuild`, 2026-06-06) and has
+## since released v4.3, so the jameslamping fork this used to pin (v4.0.4, never merged
+## upstream) is no longer needed. Note upstream master now references
+## UniversalCohorts-v2, so this pin is NOT usable by the UCLv1 `extensions-v8-release.yaml`.
+##
+## KNOWN LIMITATION -- only usable with NECN and PnET succession, NOT ForCS or Biomass
+## Succession, which crash at extension load with a NullReferenceException:
+##
+##   at Landis.Extension.SocialClimateFire.SiteVars.InitializeDisturbances()
+##        in src/SiteVars.cs:line 109
+##   at Landis.Extension.SocialClimateFire.PlugIn.LoadParameters(String, ICore)
+##
+## `InitializeDisturbances()` looks up `Succession.FineFuels`; when that is unregistered
+## it falls back to `Succession.Litter` but assigns into `SiteVars.FineFuels[site]`, whose
+## getter returns the same field it just found null (and which is never allocated with
+## `NewSiteVar<double>()`) -- so the fallback dereferences null. NECN registers
+## `Succession.FineFuels` directly and PnET registers it via `Library-PnET-Cohort`, so both
+## take the working branch; ForCS and Biomass Succession register only `Succession.Litter`.
+##
+## This is NOT a UCLv2 issue -- it reproduces on the UCLv1 pin used by the v8 image, and is
+## still present on upstream master as of v4.3 (the 2026-07-20 fineFuels refactor renamed
+## the fields but left the same null target). Verified by building this image against both
+## pins and running all four succession extensions. See the test READMEs.
 - repo: Extension-Social-Climate-Fire
-  org: jameslamping
-  commit: 4b089aff84322d11348ea0ffe63265cc1d249e10
+  org: LANDIS-II-Foundation
+  commit: 0babccb6f37c55f22a2ae632833582bea5d754d9 ## v4.3
 
 - repo: LANDIS-II-Forest-Roads-Simulation-extension
   org: Klemet

--- a/tests/TestBiomassSuccession_UCLv2_v8/README.md
+++ b/tests/TestBiomassSuccession_UCLv2_v8/README.md
@@ -30,6 +30,30 @@ It was fixed in the Biomass Succession spin-up overhaul (issue #53; the buggy li
 the source commented with `WHERE DID THIS CODE COME FROM?  HUGE MYSTERY`). A stale extension
 that reintroduced it would age cohorts by only ~+5 years over this run and fail the check.
 
+## Do not add Social Climate Fire (SCRAPPLE) to this scenario
+
+SCRAPPLE is in the image but **cannot run under Biomass Succession** (or ForCS). Adding it
+here crashes at extension load, before any input parsing:
+
+```
+Loading Social Climate Fire extension ...
+Internal error occurred within the program:
+  Object reference not set to an instance of an object.
+   at Landis.Extension.SocialClimateFire.SiteVars.InitializeDisturbances()
+        in src/SiteVars.cs:line 109          # line number is for the pinned v4.3
+   at Landis.Extension.SocialClimateFire.PlugIn.LoadParameters(String dataFile, ICore mCore)
+```
+
+SCRAPPLE reads fine fuels from `Succession.FineFuels`; when that site variable is
+unregistered it falls back to `Succession.Litter` but assigns into `SiteVars.FineFuels[site]`,
+whose getter returns the same field it just found null — so the fallback dereferences null.
+Biomass Succession and ForCS register only `Succession.Litter`; NECN registers
+`Succession.FineFuels` directly and PnET registers it via `Library-PnET-Cohort`, which is why
+SCRAPPLE works in `../TestNECN_AllExtension` and `../TestPnET_AllExtension` but not here.
+
+This is an upstream SCRAPPLE bug, **not** a UCLv2 issue — it reproduces on the UCLv1 pin used
+by `landis-ii-v8-release` and is still present on upstream master as of v4.3.
+
 ## Running it manually
 
 ```sh

--- a/tests/TestForCS_v8/scenario.txt
+++ b/tests/TestForCS_v8/scenario.txt
@@ -18,6 +18,26 @@ CellLength  100 << meters, so cell area = 1 ha
 >> Disturbance Extensions   Initialization File
 >> ----------------------   -------------------
 
+>> Social Climate Fire (SCRAPPLE): DO NOT ADD IT HERE -- it is in the image but cannot run
+>> under ForCS. It crashes at extension load, before any input parsing:
+>>
+>>   Loading Social Climate Fire extension ...
+>>   Internal error occurred within the program:
+>>     Object reference not set to an instance of an object.
+>>      at Landis.Extension.SocialClimateFire.SiteVars.InitializeDisturbances()
+>>           in src/SiteVars.cs:line 109   << line number is for the pinned v4.3
+>>
+>> SCRAPPLE reads fine fuels from `Succession.FineFuels`; when that site variable is
+>> unregistered it falls back to `Succession.Litter` but assigns into
+>> `SiteVars.FineFuels[site]`, whose getter returns the same field it just found null --
+>> so the fallback dereferences null. ForCS and Biomass Succession register only
+>> `Succession.Litter`; NECN registers `Succession.FineFuels` directly and PnET registers
+>> it via `Library-PnET-Cohort`, which is why SCRAPPLE runs in ../TestNECN_AllExtension
+>> and ../TestPnET_AllExtension but not here.
+>>
+>> Upstream SCRAPPLE bug, NOT a UCLv2 issue: it reproduces on the UCLv1 pin used by the
+>> v8 image and is still present on upstream master as of v4.3. See
+>> ../../extensions-v8-UCL2-release.yaml for the full write-up.
 
    DisturbancesRandomOrder  no  << optional parameter; default = no
 

--- a/tests/TestPnET_AllExtension/scenario_UCLv2.txt
+++ b/tests/TestPnET_AllExtension/scenario_UCLv2.txt
@@ -25,7 +25,10 @@ CellLength  30 << meters, so cell area = 900 m2
 >> Original Fire (Formerly Base Fire)
 >> 	"Original Fire"		./inputs/disturbances/originalFire/original-fire.txt
 
->> Climate-social Fire
+>> Climate-social Fire: works fine under PnET (unlike ForCS/Biomass Succession -- see
+>> ../../extensions-v8-UCL2-release.yaml), but left off because Dynamic Fire System below is
+>> this scenario's fire extension. Enabling both aborts the run: each registers "Fire.Severity"
+>> ("A site variable has already been registered with the name Fire.Severity").
 >> "Social Climate Fire"  ./inputs/disturbances/climateSocialFire/Social-Climate-Fire-Inputs.txt
 
 >> Dynamic Biomass Fuels


### PR DESCRIPTION
Repoints **Social Climate Fire (SCRAPPLE)** from the `jameslamping` fork to upstream [`0babccb`](https://github.com/LANDIS-II-Foundation/Extension-Social-Climate-Fire/commit/0babccb6f37c55f22a2ae632833582bea5d754d9) (v4.3), and documents a long-standing limitation that isn't recorded anywhere today.

## SCRAPPLE only works with NECN and PnET

It crashes at extension **load** under ForCS and Biomass Succession:

```
at Landis.Extension.SocialClimateFire.SiteVars.InitializeDisturbances()
     in src/SiteVars.cs:line 109
at Landis.Extension.SocialClimateFire.PlugIn.LoadParameters(String, ICore)
```

| Succession | Registers `Succession.FineFuels` | SCRAPPLE |
| --- | --- | --- |
| NECN | yes | ✅ runs |
| PnET | yes (via `Library-PnET-Cohort`) | ✅ runs |
| ForCS | no — only `Succession.Litter` | ❌ NRE at load |
| Biomass Succession | no — only `Succession.Litter` | ❌ NRE at load |

`InitializeDisturbances()` looks up `Succession.FineFuels`; when that is unregistered it falls back to `Succession.Litter` but assigns into `SiteVars.FineFuels[site]`, whose getter returns the same field it just found null — and which is never allocated with `NewSiteVar<double>()`. So the fallback dereferences null.

**This is not a UCLv2 issue.** It reproduces on the UCLv1 pin used by `landis-ii-v8-release`, and is still present on upstream master as of v4.3.

Note that upstream [`c6ef14e`](https://github.com/LANDIS-II-Foundation/Extension-Social-Climate-Fire/commit/c6ef14e9a04ab33f30d8eb194d876ce9d6a269db) ("Tweaks to how fineFuels is fetched from Succession", 2026-07-20) does repair the **NECN** path, which previously requested `GetSiteVar<Pool>("Succession.FineFuels")` — the `Pool` type for a name registered as `double`. The ForCS / Biomass Succession branch is unchanged apart from a field rename, so the null target remains there. That commit is an ancestor of the pin in this PR, so it is covered by the verification below. (Upstream's "4.3.1" is the Inno Setup installer version; the assembly and the LANDIS registration file both still report 4.3.)

Not pursuing an upstream fix for now. The obvious one-line change — allocating the site variable with `NewSiteVar<double>()` before populating it from the litter pool — was built and tested, and it clears the crash without regressing NECN or PnET, but it is not sufficient on its own: ForCS and Biomass Succession then hit climate prerequisites. ForCS supplies climate via its own `ForCSClimateFile` and never initialises `Landis.Library.Climate`; Biomass Succession does use that library, but SCRAPPLE needs daily climate with fire weather rather than the stock `Monthly_AverageAllYears` / `UsingFireClimate no`. Making SCRAPPLE usable under those two extensions is a larger piece of work, so documenting the limitation is the appropriate response here.

Documented at each point of use: the yaml entry, the UCLv2 README extension table, `tests/TestForCS_v8/scenario.txt`, and the `TestBiomassSuccession_UCLv2_v8` README.

## The pin change

The fork was a bridge for the UCLv2 migration and was never merged upstream — its HEAD is not an ancestor of upstream master. Upstream absorbed that work ("Update UCL and Rebuild", 2026-06-06) and has since released v4.3, so the fork is now both redundant and 3 months stale. Closes the `TODO: use LANDIS-II-Foundation` on that entry.

⚠️ Upstream master now references `UniversalCohorts-v2`, so this pin is **not** usable by the UCLv1 `extensions-v8-release.yaml`. That file keeps its older `a79e7421` pin, and the yaml comment now says so to stop the two being synced.

## Verification

Built `Docker-LANDIS-II-v8-UCL2-release` (`UBUNTU_VERSION=24.04`) end to end: SCRAPPLE compiles and registers as **v4.3**, and all four build gates pass — NECN, PnET, ForCS, Biomass Succession — including the cohort-aging regression check (`yr0=350 yr50=400, delta=50`).

The compatibility matrix above was established by running all four succession extensions against both the old and new pins.

All scenario-file edits are comment-only and change no runnable lines.

@Klemet ready for your review

🤖 Generated with [Claude Code](https://claude.com/claude-code)


