### PR TITLE
Pin the prebuilt support libraries in YAML, and fix the UCLv2 Succession-v9 mismatch

### DIFF
--- a/Docker-LANDIS-II-v7-release/Dockerfile
+++ b/Docker-LANDIS-II-v7-release/Dockerfile
@@ -97,8 +97,14 @@ WORKDIR $LANDIS_DIR
 RUN git clone $LANDIS_GITHUB/Core-Model-v7-LINUX.git \
   && dotnet build $LANDIS_CORE_DIR/Tool-Console/src -c Release
 
-## get support libraries
+## get support libraries (use specific commit in case of broken updates)
+##
+## Kept inline rather than moved to a YAML as the v8 images were: v7 is
+## superseded and these DLLs have not changed since 2024-10-11, so there is
+## nothing here to keep re-reviewing. The pin simply records what this image is
+## already building, which until now was whatever the default branch held.
 RUN git clone $LANDIS_GITHUB/Support-Library-Dlls-v7.git \
+  && git -C $LANDIS_DIR/Support-Library-Dlls-v7 checkout 539907af9e121a2da252570bbcda83765a57b162 \
   && mv $LANDIS_DIR/Support-Library-Dlls-v7/* $LANDIS_EXT_DIR/ \
   && rm -r $LANDIS_DIR/Support-Library-Dlls-v7
 

--- a/Docker-LANDIS-II-v7-release/README.md
+++ b/Docker-LANDIS-II-v7-release/README.md
@@ -37,6 +37,7 @@ docker run --rm `
 ## Included extensions
 
 See [`extensions-v7-release.yaml`](../extensions-v7-release.yaml) and [`libraries-v7-release.yaml`](../libraries-v7-release.yaml) for the exact commit SHAs used.
+The prebuilt `Support-Library-Dlls-v7` commit is pinned inline in the Dockerfile rather than in a `.yaml`: v7 is superseded and those DLLs have not changed since 2024-10-11, so there is nothing there to keep re-reviewing.
 
 **Succession**
 
@@ -91,7 +92,8 @@ See [`extensions-v7-release.yaml`](../extensions-v7-release.yaml) and [`librarie
 This image supersedes `Clean_Docker_LANDIS-II_7_AllExtensions` with the following improvements:
 
 - LANDIS-II placed at `/opt/landis-ii` (standard location for third-party software);
-- extension and library versions defined in shared `*.yaml` files, not hardcoded in the Dockerfile;
+- extension and library versions defined in shared `*.yaml` files, not hardcoded in the Dockerfile
+  (the exception being the prebuilt `Support-Library-Dlls-v7` commit, pinned inline: see above);
 - shared `.csproj` files for Forest Roads and Magic Harvest extensions (`extension_files_v7/`);
 - build scripts rewritten in `bash`, shared in `scripts/`, reusable across image flavours;
 - `yq` used to parse yaml; `xmlstarlet` used to edit `.csproj` XML;

--- a/Docker-LANDIS-II-v8-R/Dockerfile
+++ b/Docker-LANDIS-II-v8-R/Dockerfile
@@ -83,11 +83,18 @@ RUN git clone $LANDIS_GITHUB/Core-Model-v8-LINUX.git \
   && git -C $LANDIS_CORE_DIR checkout 8725da5cd7bfdf3ae28bbd59b1353ec442783d68 \
   && dotnet build $LANDIS_CORE_DIR/Tool-Console/src -c Release
 
-## get support libraries (use specific commit in case of broken updates)
-RUN git clone $LANDIS_GITHUB/Support-Library-Dlls-v8.git \
-  && git -C $LANDIS_DIR/Support-Library-Dlls-v8 checkout f8178b2a8f8d39bf8c4f1884cc446e4e34fee1ff \
-  && mv $LANDIS_DIR/Support-Library-Dlls-v8/* $LANDIS_EXT_DIR/ \
-  && rm -r $LANDIS_DIR/Support-Library-Dlls-v8
+## get the prebuilt support libraries
+##
+##  - the commit is pinned in `support-libraries-v8-release.yaml`, so it is
+##    reviewable alongside the extension and library pins rather than buried here;
+##  - these are copied into `build/extensions` BEFORE the extensions are compiled,
+##    because extensions reference them through HintPaths into that directory;
+##  - they are NOT part of `libraries-v8-release.yaml`: those entries are built from
+##    source with `dotnet build`, and applied after the extensions are built.
+
+COPY support-libraries-v8-release.yaml $LANDIS_DIR/support-libraries-v8-release.yaml
+
+RUN scripts/install_support_libraries_v8.sh support-libraries-v8-release.yaml $LANDIS_DIR
 
 ## get, build, and register all available extensions
 ##

--- a/Docker-LANDIS-II-v8-Rstudio/Dockerfile
+++ b/Docker-LANDIS-II-v8-Rstudio/Dockerfile
@@ -80,11 +80,18 @@ RUN git clone $LANDIS_GITHUB/Core-Model-v8-LINUX.git \
   && git -C $LANDIS_CORE_DIR checkout 8725da5cd7bfdf3ae28bbd59b1353ec442783d68 \
   && dotnet build $LANDIS_CORE_DIR/Tool-Console/src -c Release
 
-## get support libraries (use specific commit in case of broken updates)
-RUN git clone $LANDIS_GITHUB/Support-Library-Dlls-v8.git \
-  && git -C $LANDIS_DIR/Support-Library-Dlls-v8 checkout f8178b2a8f8d39bf8c4f1884cc446e4e34fee1ff \
-  && mv $LANDIS_DIR/Support-Library-Dlls-v8/* $LANDIS_EXT_DIR/ \
-  && rm -r $LANDIS_DIR/Support-Library-Dlls-v8
+## get the prebuilt support libraries
+##
+##  - the commit is pinned in `support-libraries-v8-release.yaml`, so it is
+##    reviewable alongside the extension and library pins rather than buried here;
+##  - these are copied into `build/extensions` BEFORE the extensions are compiled,
+##    because extensions reference them through HintPaths into that directory;
+##  - they are NOT part of `libraries-v8-release.yaml`: those entries are built from
+##    source with `dotnet build`, and applied after the extensions are built.
+
+COPY support-libraries-v8-release.yaml $LANDIS_DIR/support-libraries-v8-release.yaml
+
+RUN scripts/install_support_libraries_v8.sh support-libraries-v8-release.yaml $LANDIS_DIR
 
 ## get, build, and register all available extensions
 ##

--- a/Docker-LANDIS-II-v8-UCL2-release/Dockerfile
+++ b/Docker-LANDIS-II-v8-UCL2-release/Dockerfile
@@ -103,11 +103,18 @@ RUN git clone $LANDIS_GITHUB/Core-Model-v8-LINUX.git \
   && git -C $LANDIS_CORE_DIR checkout 8725da5cd7bfdf3ae28bbd59b1353ec442783d68 \
   && dotnet build $LANDIS_CORE_DIR/Tool-Console/src -c Release
 
-## get support libraries (use specific commit in case of broken updates)
-RUN git clone $LANDIS_GITHUB/Support-Library-Dlls-v8.git \
-  && git -C $LANDIS_DIR/Support-Library-Dlls-v8 checkout 69d615f07ad0f4fb0cac38fee7ae949bb1722fe1 \
-  && mv $LANDIS_DIR/Support-Library-Dlls-v8/* $LANDIS_EXT_DIR/ \
-  && rm -r $LANDIS_DIR/Support-Library-Dlls-v8
+## get the prebuilt support libraries
+##
+##  - the commit is pinned in `support-libraries-v8-UCL2-release.yaml`, so it is
+##    reviewable alongside the extension and library pins rather than buried here;
+##  - these are copied into `build/extensions` BEFORE the extensions are compiled,
+##    because extensions reference them through HintPaths into that directory;
+##  - they are NOT part of `libraries-v8-release.yaml`: those entries are built from
+##    source with `dotnet build`, and applied after the extensions are built.
+
+COPY support-libraries-v8-UCL2-release.yaml $LANDIS_DIR/support-libraries-v8-UCL2-release.yaml
+
+RUN scripts/install_support_libraries_v8.sh support-libraries-v8-UCL2-release.yaml $LANDIS_DIR
 
 ## rebuild the support libraries that the extensions must *compile against*
 ##

--- a/Docker-LANDIS-II-v8-UCL2-release/README.md
+++ b/Docker-LANDIS-II-v8-UCL2-release/README.md
@@ -39,6 +39,7 @@ docker run --rm `
 ## Included extensions
 
 See [`extensions-v8-UCL2-release.yaml`](../extensions-v8-UCL2-release.yaml),
+[`support-libraries-v8-UCL2-release.yaml`](../support-libraries-v8-UCL2-release.yaml),
 [`libraries-v8-UCL2-prebuild.yaml`](../libraries-v8-UCL2-prebuild.yaml), and
 [`libraries-v8-release.yaml`](../libraries-v8-release.yaml) for the exact commit SHAs used.
 
@@ -105,6 +106,10 @@ All other enhancements from `Docker-LANDIS-II-v8-release` also apply:
 - shared `.csproj` files for Forest Roads and Magic Harvest extensions (`extension_files/`);
   this build selects the UCLv2 Forest Roads variant (`Forest-Roads-Extension-UCLv2.csproj`)
   via the `csproj:` field on its entry in `extensions-v8-UCL2-release.yaml`;
+- the prebuilt support libraries pinned in `support-libraries-v8-UCL2-release.yaml` and copied
+  into `build/extensions` before the extensions are compiled. Pinned separately from the UCLv1
+  images, which use a different commit of the same repo, and kept out of `libraries-v8-*.yaml`
+  because those entries are built from source with `dotnet build`, afterwards;
 - a pre-extension support-library pass (`libraries-v8-UCL2-prebuild.yaml`) that rebuilds
   `Landis.Library.PnETCohorts-v2` from its UCLv2 branch, because `Support-Library-Dlls-v8`
   still ships the UCLv1 build (v2.1.1) that the PnET extensions cannot compile against;

--- a/Docker-LANDIS-II-v8-release/Dockerfile
+++ b/Docker-LANDIS-II-v8-release/Dockerfile
@@ -103,11 +103,18 @@ RUN git clone $LANDIS_GITHUB/Core-Model-v8-LINUX.git \
   && git -C $LANDIS_CORE_DIR checkout 8725da5cd7bfdf3ae28bbd59b1353ec442783d68 \
   && dotnet build $LANDIS_CORE_DIR/Tool-Console/src -c Release
 
-## get support libraries (use specific commit in case of broken updates)
-RUN git clone $LANDIS_GITHUB/Support-Library-Dlls-v8.git \
-  && git -C $LANDIS_DIR/Support-Library-Dlls-v8 checkout f8178b2a8f8d39bf8c4f1884cc446e4e34fee1ff \
-  && mv $LANDIS_DIR/Support-Library-Dlls-v8/* $LANDIS_EXT_DIR/ \
-  && rm -r $LANDIS_DIR/Support-Library-Dlls-v8
+## get the prebuilt support libraries
+##
+##  - the commit is pinned in `support-libraries-v8-release.yaml`, so it is
+##    reviewable alongside the extension and library pins rather than buried here;
+##  - these are copied into `build/extensions` BEFORE the extensions are compiled,
+##    because extensions reference them through HintPaths into that directory;
+##  - they are NOT part of `libraries-v8-release.yaml`: those entries are built from
+##    source with `dotnet build`, and applied after the extensions are built.
+
+COPY support-libraries-v8-release.yaml $LANDIS_DIR/support-libraries-v8-release.yaml
+
+RUN scripts/install_support_libraries_v8.sh support-libraries-v8-release.yaml $LANDIS_DIR
 
 ## get, build, and register all available extensions
 ##

--- a/Docker-LANDIS-II-v8-release/README.md
+++ b/Docker-LANDIS-II-v8-release/README.md
@@ -36,7 +36,7 @@ docker run --rm `
 
 ## Included extensions
 
-See [`extensions-v8-release.yaml`](../extensions-v8-release.yaml) and [`libraries-v8-release.yaml`](../libraries-v8-release.yaml) for the exact commit SHAs used.
+See [`extensions-v8-release.yaml`](../extensions-v8-release.yaml), [`libraries-v8-release.yaml`](../libraries-v8-release.yaml), and [`support-libraries-v8-release.yaml`](../support-libraries-v8-release.yaml) for the exact commit SHAs used.
 
 **Succession**
 

--- a/scripts/install_support_libraries_v8.sh
+++ b/scripts/install_support_libraries_v8.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -e
+
+## Install the PREBUILT support-library DLLs into the extensions directory.
+##
+## Distinct from `install_libraries_v8.sh`, which clones a library's source and
+## runs `dotnet build` on it. The repos handled here ship compiled .dll files and
+## no .csproj, so they are cloned and copied, never built. They are also applied
+## BEFORE the extensions are compiled, because extensions reference these .dll
+## files through HintPaths into the extensions directory -- which is why the pin
+## cannot live in `libraries-v8-*.yaml` (built from source, and afterwards).
+
+## Validate input
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <support-libraries.yaml> <landis_directory>"
+  exit 1
+fi
+
+YAML_FILE="$1"
+LANDIS_DIR="$2"
+
+## Ensure these env vars match those in the Dockerfile!!
+LANDIS_CORE_DIR="$LANDIS_DIR/Core-Model-v8-LINUX"
+LANDIS_EXT_DIR="$LANDIS_CORE_DIR/build/extensions"
+
+## Ensure the extensions directory exists: the core model must already be built,
+## otherwise the DLLs would be copied somewhere nothing will look for them.
+if [ ! -d "$LANDIS_EXT_DIR" ]; then
+  echo "Error: directory $LANDIS_EXT_DIR not found" 1>&2
+  exit 1
+fi
+
+## Get total number of repos to process
+count=$(yq eval 'length' "$YAML_FILE")
+
+for i in $(seq 0 $((count - 1))); do
+  repo=$(yq eval ".[$i].repo" "$YAML_FILE")
+  org=$(yq eval ".[$i].org" "$YAML_FILE")
+  commit=$(yq eval ".[$i].commit" "$YAML_FILE")
+
+  if [[ -z "$repo" || -z "$org" || -z "$commit" || "$commit" == "null" ]]; then
+    echo "Error parsing $YAML_FILE" 1>&2
+    exit 1
+  fi
+
+  ## Clone repo and checkout specific commit
+  echo "Cloning $org/$repo at commit $commit ..."
+
+  repo_path="$LANDIS_DIR/$repo"
+  url="https://github.com/$org/$repo.git"
+
+  git clone "$url" "$repo_path"
+  git -C "$repo_path" checkout "$commit"
+
+  ## Copy the prebuilt DLLs into place, then drop the clone (including its .git
+  ## directory, which `mv repo/*` deliberately leaves behind).
+  echo "Installing prebuilt support libraries from $repo ..."
+  mv "$repo_path"/* "$LANDIS_EXT_DIR/"
+  rm -rf "$repo_path"
+done

--- a/support-libraries-v8-UCL2-release.yaml
+++ b/support-libraries-v8-UCL2-release.yaml
@@ -1,0 +1,14 @@
+## Prebuilt support-library DLLs for the v8 UCLv2 image.
+##
+## These are copied into `build/extensions` BEFORE the extensions are compiled,
+## because extensions reference them through HintPaths into that directory.
+## That is why they are not part of `libraries-v8-release.yaml`: those entries
+## are built from source with `dotnet build`, and applied AFTER the extensions.
+## Installed by `scripts/install_support_libraries_v8.sh`.
+##
+## Pinned separately from `support-libraries-v8-release.yaml`: this image and the
+## UCLv1 images have always used different commits of the same repo.
+
+- repo: Support-Library-Dlls-v8
+  org: LANDIS-II-Foundation
+  commit: 69d615f07ad0f4fb0cac38fee7ae949bb1722fe1

--- a/support-libraries-v8-UCL2-release.yaml
+++ b/support-libraries-v8-UCL2-release.yaml
@@ -7,8 +7,19 @@
 ## Installed by `scripts/install_support_libraries_v8.sh`.
 ##
 ## Pinned separately from `support-libraries-v8-release.yaml`: this image and the
-## UCLv1 images have always used different commits of the same repo.
+## UCLv1 images have always used different commits of the same repo, and the
+## mismatch described below affects only this one.
 
 - repo: Support-Library-Dlls-v8
   org: LANDIS-II-Foundation
-  commit: 69d615f07ad0f4fb0cac38fee7ae949bb1722fe1
+  ## Bumped from 69d615f0, which shipped `Landis.Library.HarvestManagement-v5.dll`
+  ## and `Landis.Library.SiteHarvest-v3.dll` built against `Succession-v9` while
+  ## every other extension in this image is on `Succession-v10` (see #66, #68).
+  ## This commit also drops `Landis.Extension.BiomassHarvest-v6.dll`, a UCLv1
+  ## extension binary that has no business in the UCLv2 image -- Biomass Harvest
+  ## is built from source here.
+  ##
+  ## NOTE: this does NOT retire `libraries-v8-UCL2-prebuild.yaml`.
+  ## `Landis.Library.PnETCohorts-v2.dll` is still the UCLv1 build even at this
+  ## commit, so that rebuild is still required.
+  commit: f0b0d68e16f45ee3549787e98f622eb8bb170171

--- a/support-libraries-v8-release.yaml
+++ b/support-libraries-v8-release.yaml
@@ -1,0 +1,11 @@
+## Prebuilt support-library DLLs for the v8 (UCLv1) images.
+##
+## These are copied into `build/extensions` BEFORE the extensions are compiled,
+## because extensions reference them through HintPaths into that directory.
+## That is why they are not part of `libraries-v8-release.yaml`: those entries
+## are built from source with `dotnet build`, and applied AFTER the extensions.
+## Installed by `scripts/install_support_libraries_v8.sh`.
+
+- repo: Support-Library-Dlls-v8
+  org: LANDIS-II-Foundation
+  commit: f8178b2a8f8d39bf8c4f1884cc446e4e34fee1ff


### PR DESCRIPTION
Fixes #66. Unblocks #68 (no further Forest Roads change needed). Context: #43.

## The bug

`Docker-LANDIS-II-v8-UCL2-release/Dockerfile` pinned `Support-Library-Dlls-v8` at `69d615f0`, which ships two libraries built against `UniversalCohorts-v2` but still against `Succession-v9`, into an image where every extension is on `Succession-v10`.

Scanning the assembly references of every DLL in the repo at each candidate commit (.NET stores them as plain strings in metadata, so this needs no .NET tooling):

| DLL | `69d615f0` (was pinned) | `4c7f438e` | `f0b0d68e` (HEAD, now pinned) |
|---|---|---|---|
| `Landis.Library.HarvestManagement-v5.dll` | UC-v2, **Succ-v9** | UC-v2, Succ-v10 | UC-v2, Succ-v10 |
| `Landis.Library.SiteHarvest-v3.dll` | UC-v2, **Succ-v9** | UC-v2, Succ-v10 | UC-v2, Succ-v10 |
| `Landis.Extension.BiomassHarvest-v6.dll` | present, UC-v1/Succ-v9 | present, UC-v1/Succ-v9 | **removed** |
| the other 17 DLLs | unchanged across all three | | |

`f0b0d68e` is preferred over `4c7f438e` (the commit tested in #66) because it also drops
`Landis.Extension.BiomassHarvest-v6.dll` — a UCLv1 *extension* binary shipping inside a library repo and landing in `build/extensions` of the UCLv2 image, where Biomass Harvest is built from source anyway.

**This is also what breaks the Forest Roads build in #68.** Moving that extension to
`HarvestManagement-v5` is correct, but at the old pin `-v5` drags `Succession-v9` back into the image, so the `.csproj` fix could not pass its tests until the support libraries moved. Both halves of that fix (b4a584a, cd84691) are already in; nothing further is needed there.

Only the UCLv2 image is affected — the UCLv1 images pin `f8178b2a`, and every v1-generation DLL is byte-identical across all of these commits.

## Why the pin moved to YAML

This was the only version-bearing pin in the build that was not reviewable where the others are: extension commits live in `extensions-v8-*.yaml` and library rebuilds in `libraries-v8-*.yaml`, while this was a bare SHA inside a `RUN git clone` in four Dockerfiles. Nothing surfaces when it drifts out of step with the extensions it ships alongside, and it has now drifted twice (#66, #68), each time appearing downstream as an obscure runtime error rather than a version mismatch.

It is **not** folded into `libraries-v8-*.yaml`, for two reasons:

* **different behaviour** — `install_libraries_v8.sh` clones a library's source and runs `dotnet build` on a discovered `.csproj`; these repos ship compiled `.dll` files and no project file, so they are cloned and copied, never built;
* **different phase** — the prebuilt DLLs must be in `build/extensions` *before* the extensions compile, since extensions reference them through HintPaths into that directory, whereas `libraries-v8-release.yaml` is applied afterwards.

Two YAMLs because the UCLv1 images and the UCLv2 image have always pinned different commits of the same repo.

## Commits

1. **Mechanism, behaviour-preserving.** Adds `scripts/install_support_libraries_v8.sh`, `support-libraries-v8-release.yaml` and `support-libraries-v8-UCL2-release.yaml` at each Dockerfile's *existing* SHA, and converts the four v8 Dockerfiles. No image content changes.
2. **The fix.** Bumps `support-libraries-v8-UCL2-release.yaml` to `f0b0d68e`. One line.
3. **v7 pin** (independent — drop if unwanted). `Docker-LANDIS-II-v7-release` cloned `Support-Library-Dlls-v7` with no `checkout` at all, so the image took whatever the default branch held and was not reproducible. Pinned to that repo's current HEAD, so it records what is already being built rather than changing it. Kept inline rather than moved to YAML: v7 is superseded and those DLLs have not changed since 2024-10-11.

READMEs are updated in the commits that introduce the changes.

The `Clean_Docker_LANDIS-II_*` images keep their inline pins, as superseded.

## What this does NOT do

It does **not** retire `libraries-v8-UCL2-prebuild.yaml`. `Landis.Library.PnETCohorts-v2.dll` is still the UCLv1 build even at `f0b0d68e`, so that pre-extension rebuild is still required. Flagging it because a support-library bump looks like it should retire the workaround.

**Worth doing separately:** if `Support-Library-Dlls-v8` rebuilt `Landis.Library.PnETCohorts-v2.dll` against `UniversalCohorts-v2` / `InitialCommunity.Universal-v2`, then that file, its `COPY`/`RUN` pair, and an entire build phase could be *deleted* — which is the retirement condition its own header already names. Same class of defect as this PR fixes, just a different DLL.

## Testing

* `install_support_libraries_v8.sh` exercised end-to-end in a container mirroring the Dockerfile's `ARG`/`WORKDIR`/`COPY`/`RUN` structure, with real `yq` and the real build context: clones, checks out, copies 21 files into `build/extensions`, removes the clone. Verified for both the old and new pins.
* The resulting library set at `f0b0d68e` re-scanned: no `UniversalCohorts-v2` file references `Succession-v9`.
* Both YAMLs validated for schema (`repo`/`org`/`commit`), `bash -n` clean.
* Build context confirmed as the repo root for every active image, so `COPY support-libraries-*.yaml` resolves exactly as the existing `COPY libraries-v8-release.yaml` does.

**Not tested locally:** a full image build. The extensions still need to compile against the bumped libraries, and CI here is the real check — the run that failed in #68 should now go green with no further change to Forest Roads.

## Possible follow-up

A build-time assertion that everything in `build/extensions` agrees on generation, failing the build and naming the offending files, would have caught this at build time rather than downstream. It is 30 lines over `strings` (it produced the table above) and would need scoping to the generation each image targets, since v1 and v2 DLLs legitimately coexist in the source repo. Happy to open that separately if it is wanted — it will likely surface pre-existing warnings that deserve their own discussion.

@Klemet ready for your review