### PR TITLE
Harden CI against two transient failure modes seen in #70's follow-on builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,6 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      ## Cap concurrent legs. Every leg ends by pushing a multi-hundred-MB image to GHCR, and
+      ## running all of them at once trips GitHub's secondary rate limit, which surfaces as a
+      ## push failure reading `denied: permission_denied ... 403 Forbidden` -- the body, not the
+      ## prefix, is where it says "You have exceeded a secondary rate limit". That reads as a
+      ## credentials problem and is not one, which makes it expensive to diagnose. Observed on a
+      ## fork build of 2026-08-18. Builds still run in parallel, just fewer at a time.
+      max-parallel: 3
       matrix:
         include:
           # - dockercontext: ./Clean_Docker_LANDIS-II_7_AllExtensions

--- a/scripts/install_support_libraries_v8.sh
+++ b/scripts/install_support_libraries_v8.sh
@@ -50,7 +50,31 @@ for i in $(seq 0 $((count - 1))); do
   repo_path="$LANDIS_DIR/$repo"
   url="https://github.com/$org/$repo.git"
 
-  git clone "$url" "$repo_path"
+  ## Retry the clone. This is a plain network fetch in the middle of a long image
+  ## build, so a transient failure throws away everything built so far. Observed on a
+  ## fork build of 2026-08-18, 91 s into the clone:
+  ##   fatal: unable to access '...': GnuTLS, handshake failed: The TLS connection
+  ##   was non-properly terminated.
+  ## while the very same step succeeded in the sibling matrix leg. A partial clone
+  ## leaves the directory behind and would make the next attempt fail with "already
+  ## exists", so remove it before retrying.
+  clone_ok=false
+  for attempt in 1 2 3; do
+    if git clone "$url" "$repo_path"; then
+      clone_ok=true
+      break
+    fi
+    echo "  clone attempt $attempt/3 failed" 1>&2
+    rm -rf "$repo_path"
+    if [ "$attempt" -lt 3 ]; then
+      sleep $((attempt * 10))
+    fi
+  done
+  if [ "$clone_ok" != true ]; then
+    echo "Error: failed to clone $url after 3 attempts" 1>&2
+    exit 1
+  fi
+
   git -C "$repo_path" checkout "$commit"
 
   ## Copy the prebuilt DLLs into place, then drop the clone (including its .git


### PR DESCRIPTION
Two independent transient failures showed up in fork builds after #70 merged. Neither is a defect in the build itself; both are worth absorbing rather than re-diagnosing each time.

## 1. GHCR secondary rate limit on push

All seven matrix legs finish by pushing a multi-hundred-MB image at once, which trips GitHub's secondary rate limit. The failure reads:

```
denied: permission_denied: Error from intermediary with HTTP status code 403 "Forbidden"
 - with-body: { ... "You have exceeded a secondary rate limit." }
```

An unhelpful pairing: the prefix says permission denied, the body says rate limit. It reads as a credentials or package-visibility problem and is not one, which makes it expensive to chase. Observed 2026-08-18, where the Rstudio leg failed this way while the other six pushed fine.

`max-parallel: 3` keeps the legs parallel but staggers the pushes. Costs some wall-clock on a full rebuild; cheaper than a spurious failure that looks like something else.

## 2. Transient clone failure aborts the whole build

`install_support_libraries_v8.sh` does a plain network fetch partway through a long build, so a blip discards everything built so far. Same run, 91 s in:

```
fatal: unable to access '.../Support-Library-Dlls-v8.git/': GnuTLS, handshake failed:
  The TLS connection was non-properly terminated.
```

while the identical step in the sibling matrix leg succeeded. The inline `RUN git clone` this replaced had the same exposure, so this is not a regression from #70 -- just the obvious place to fix it now that the clone lives in a script.

Three attempts, 10 s / 20 s backoff, removing the partial clone between tries so the retry cannot fail with "already exists" for the wrong reason. Still exits non-zero after three failures, naming the URL.

## Testing

Both script paths exercised directly: an unreachable repo retries three times, backs off, and exits 1; a real clone still installs its 21 files and cleans up after itself. The workflow YAML parses with 7 active legs and `max-parallel: 3`.

The two commits are independent -- happy to split if you'd rather take one.

@Klemet ready for your review